### PR TITLE
Centralize SiteHeader usage in BaseLayout

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,7 @@
 ---
 import '../styles/global.css';
 import Footer from '../components/Footer.astro';
+import SiteHeader from '../components/SiteHeader.astro';
 
 interface Props {
   title?: string;
@@ -23,6 +24,8 @@ interface Props {
       image?: string;
     };
   };
+  navActive?: string;
+  showSiteHeader?: boolean;
 }
 
 const {
@@ -30,6 +33,8 @@ const {
   description = "arc^ is an open research framework building plasma technology for ecological repair. We work openly, share everything, and build technology that serves life over profit.",
   bodyClass = "",
   seo = {},
+  navActive = "home",
+  showSiteHeader = true,
 } = Astro.props;
 
 // SEO data
@@ -110,10 +115,14 @@ const bodyClasses = ["site-body", bodyClass].filter(Boolean).join(" ");
   <body class={bodyClasses}>
     <!-- Skip to main content -->
     <a href="#main-content" class="skip-link">Skip to main content</a>
-    
+
+    <slot name="before-header" />
+
+    {showSiteHeader && <SiteHeader active={navActive} />}
+
     <!-- Page content -->
     <slot />
-    
+
     <!-- Universal footer -->
     <Footer />
     

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,7 +1,6 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 import ArcCanvas from "../components/ArcCanvas.astro";
-import SiteHeader from "../components/SiteHeader.astro";
 import PageNavigation from "../components/PageNavigation.astro";
 import Card from "../components/Card.astro";
 import LinkButton from "../components/LinkButton.astro";
@@ -20,9 +19,14 @@ const seo = buildSEO({
 });
 ---
 
-<BaseLayout title={seo.title} description={seo.description} seo={seo} bodyClass="page-generic">
-  <ArcCanvas />
-  <SiteHeader active="about" />
+<BaseLayout
+  title={seo.title}
+  description={seo.description}
+  seo={seo}
+  bodyClass="page-generic"
+  navActive="about"
+>
+  <ArcCanvas slot="before-header" />
 
   <main id="main-content" class="page-shell" aria-labelledby="page-title">
 

--- a/src/pages/about/founder.astro
+++ b/src/pages/about/founder.astro
@@ -6,7 +6,6 @@
  */
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import ArcCanvas from "../../components/ArcCanvas.astro";
-import SiteHeader from "../../components/SiteHeader.astro";
 import PageNavigation from "../../components/PageNavigation.astro";
 import Card from "../../components/Card.astro";
 import LinkButton from "../../components/LinkButton.astro";
@@ -26,9 +25,14 @@ const seo = buildSEO({
 });
 ---
 
-<BaseLayout title={seo.title} description={seo.description} bodyClass="page-about" seo={seo}>
-  <ArcCanvas />
-  <SiteHeader active="about" />
+<BaseLayout
+  title={seo.title}
+  description={seo.description}
+  bodyClass="page-about"
+  seo={seo}
+  navActive="about"
+>
+  <ArcCanvas slot="before-header" />
 
   <main id="main-content" class="page-shell" aria-labelledby="founder-title">
     

--- a/src/pages/about/mission.astro
+++ b/src/pages/about/mission.astro
@@ -1,6 +1,5 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro";
-import SiteHeader from "../../components/SiteHeader.astro";
 import Card from "../../components/Card.astro";
 import LinkButton from "../../components/LinkButton.astro";
 import { withBase } from '../../utils/paths';
@@ -14,9 +13,13 @@ const seo = buildSEO({
 });
 ---
 
-<BaseLayout {...seo}>
-  <SiteHeader active="about" />
-  
+<BaseLayout
+  title={seo.title}
+  description={seo.description}
+  seo={seo}
+  bodyClass="page-about"
+  navActive="about"
+>
   <main id="main-content" class="page-shell page-mission">
     
     <!-- Breadcrumb -->

--- a/src/pages/about/origin.astro
+++ b/src/pages/about/origin.astro
@@ -1,6 +1,5 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro";
-import SiteHeader from "../../components/SiteHeader.astro";
 import Card from "../../components/Card.astro";
 import LinkButton from "../../components/LinkButton.astro";
 import { withBase } from '../../utils/paths';
@@ -14,9 +13,13 @@ const seo = buildSEO({
 });
 ---
 
-<BaseLayout title={seo.title} description={seo.description} seo={seo} bodyClass="page-about">
-  <SiteHeader active="about" />
-  
+<BaseLayout
+  title={seo.title}
+  description={seo.description}
+  seo={seo}
+  bodyClass="page-about"
+  navActive="about"
+>
   <main id="main-content" class="page-shell page-origin">
     
     <!-- Breadcrumb -->

--- a/src/pages/draft/about.astro
+++ b/src/pages/draft/about.astro
@@ -1,7 +1,6 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import ArcCanvas from "../../components/ArcCanvas.astro";
-import SiteHeader from "../../components/SiteHeader.astro";
 import PageNavigation from "../../components/PageNavigation.astro";
 import Card from "../../components/Card.astro";
 import LinkButton from "../../components/LinkButton.astro";
@@ -23,9 +22,14 @@ const seo = buildSEO({
 });
 ---
 
-<BaseLayout title={seo.title} description={seo.description} seo={seo} bodyClass="page-generic">
-  <ArcCanvas />
-  <SiteHeader active="about" />
+<BaseLayout
+  title={seo.title}
+  description={seo.description}
+  seo={seo}
+  bodyClass="page-generic"
+  navActive="about"
+>
+  <ArcCanvas slot="before-header" />
 
   <main id="main-content" class="page-shell" aria-labelledby="page-title">
 

--- a/src/pages/draft/founder.astro
+++ b/src/pages/draft/founder.astro
@@ -11,7 +11,6 @@
 
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import ArcCanvas from "../../components/ArcCanvas.astro";
-import SiteHeader from "../../components/SiteHeader.astro";
 import PageNavigation from "../../components/PageNavigation.astro";
 import SectionHeader from "../../components/SectionHeader.astro";
 import SectionDivider from "../../components/SectionDivider.astro";
@@ -32,9 +31,14 @@ const seo = buildSEO({
 });
 ---
 
-<BaseLayout title={seo.title} description={seo.description} seo={seo} bodyClass="page-about">
-  <ArcCanvas />
-  <SiteHeader active="about" />
+<BaseLayout
+  title={seo.title}
+  description={seo.description}
+  seo={seo}
+  bodyClass="page-about"
+  navActive="about"
+>
+  <ArcCanvas slot="before-header" />
 
   <main id="main-content" class="page-shell" aria-labelledby="page-title">
 

--- a/src/pages/draft/mission.astro
+++ b/src/pages/draft/mission.astro
@@ -10,7 +10,6 @@
 
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import ArcCanvas from "../../components/ArcCanvas.astro";
-import SiteHeader from "../../components/SiteHeader.astro";
 import PageNavigation from "../../components/PageNavigation.astro";
 import SectionHeader from "../../components/SectionHeader.astro";
 import SectionDivider from "../../components/SectionDivider.astro";
@@ -31,9 +30,14 @@ const seo = buildSEO({
 });
 ---
 
-<BaseLayout title={seo.title} description={seo.description} seo={seo} bodyClass="page-about">
-  <ArcCanvas />
-  <SiteHeader active="about" />
+<BaseLayout
+  title={seo.title}
+  description={seo.description}
+  seo={seo}
+  bodyClass="page-about"
+  navActive="about"
+>
+  <ArcCanvas slot="before-header" />
 
   <main id="main-content" class="page-shell" aria-labelledby="page-title">
 

--- a/src/pages/draft/origin.astro
+++ b/src/pages/draft/origin.astro
@@ -11,7 +11,6 @@
 
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import ArcCanvas from "../../components/ArcCanvas.astro";
-import SiteHeader from "../../components/SiteHeader.astro";
 import PageNavigation from "../../components/PageNavigation.astro";
 import SectionHeader from "../../components/SectionHeader.astro";
 import SectionDivider from "../../components/SectionDivider.astro";
@@ -31,9 +30,14 @@ const seo = buildSEO({
 });
 ---
 
-<BaseLayout title={seo.title} description={seo.description} seo={seo} bodyClass="page-about">
-  <ArcCanvas />
-  <SiteHeader active="about" />
+<BaseLayout
+  title={seo.title}
+  description={seo.description}
+  seo={seo}
+  bodyClass="page-about"
+  navActive="about"
+>
+  <ArcCanvas slot="before-header" />
 
   <main id="main-content" class="page-shell" aria-labelledby="page-title">
 

--- a/src/pages/how.astro
+++ b/src/pages/how.astro
@@ -6,7 +6,6 @@
  */
 import BaseLayout from "../layouts/BaseLayout.astro";
 import ArcCanvas from "../components/ArcCanvas.astro";
-import SiteHeader from "../components/SiteHeader.astro";
 import PageNavigation from "../components/PageNavigation.astro";
 import Card from "../components/Card.astro";
 import LinkButton from "../components/LinkButton.astro";
@@ -25,9 +24,14 @@ const seo = buildSEO({
 });
 ---
 
-<BaseLayout title={seo.title} description={seo.description} bodyClass="page-how" seo={seo}>
-  <ArcCanvas />
-  <SiteHeader active="how" />
+<BaseLayout
+  title={seo.title}
+  description={seo.description}
+  bodyClass="page-how"
+  seo={seo}
+  navActive="how"
+>
+  <ArcCanvas slot="before-header" />
 
   <main id="main-content" class="page-shell" aria-labelledby="how-title">
     

--- a/src/pages/how/licensing.astro
+++ b/src/pages/how/licensing.astro
@@ -6,7 +6,6 @@
  */
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import ArcCanvas from "../../components/ArcCanvas.astro";
-import SiteHeader from "../../components/SiteHeader.astro";
 import PageNavigation from "../../components/PageNavigation.astro";
 import Card from "../../components/Card.astro";
 import LinkButton from "../../components/LinkButton.astro";
@@ -26,9 +25,14 @@ const seo = buildSEO({
 });
 ---
 
-<BaseLayout title={seo.title} description={seo.description} bodyClass="page-licensing" seo={seo}>
-  <ArcCanvas />
-  <SiteHeader active="how" />
+<BaseLayout
+  title={seo.title}
+  description={seo.description}
+  bodyClass="page-licensing"
+  seo={seo}
+  navActive="how"
+>
+  <ArcCanvas slot="before-header" />
 
   <main id="main-content" class="page-shell" aria-labelledby="licensing-title">
     

--- a/src/pages/how/safety.astro
+++ b/src/pages/how/safety.astro
@@ -7,7 +7,6 @@
  */
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import ArcCanvas from "../../components/ArcCanvas.astro";
-import SiteHeader from "../../components/SiteHeader.astro";
 import PageNavigation from "../../components/PageNavigation.astro";
 import Card from "../../components/Card.astro";
 import LinkButton from "../../components/LinkButton.astro";
@@ -26,9 +25,14 @@ const seo = buildSEO({
 });
 ---
 
-<BaseLayout title={seo.title} description={seo.description} bodyClass="page-safety" seo={seo}>
-  <ArcCanvas />
-  <SiteHeader active="how" />
+<BaseLayout
+  title={seo.title}
+  description={seo.description}
+  bodyClass="page-safety"
+  seo={seo}
+  navActive="how"
+>
+  <ArcCanvas slot="before-header" />
 
   <main id="main-content" class="page-shell" aria-labelledby="safety-title">
     

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,7 +4,6 @@
 // ============================================================================
 import BaseLayout from "../layouts/BaseLayout.astro";
 import ArcCanvas from "../components/ArcCanvas.astro";
-import SiteHeader from "../components/SiteHeader.astro";
 import PageNavigation from "../components/PageNavigation.astro";
 import LinkButton from "../components/LinkButton.astro";
 import '../styles/pages/home.css';
@@ -24,14 +23,14 @@ const seo = buildSEO({
 });
 ---
 
-<BaseLayout 
+<BaseLayout
   title={seo.title}
-  description={seo.description} 
-  bodyClass="page-home" 
+  description={seo.description}
+  bodyClass="page-home"
   seo={seo}
+  navActive="home"
 >
-  <ArcCanvas />
-  <SiteHeader active="home" />
+  <ArcCanvas slot="before-header" />
 
   <main id="main-content" class="page-shell" aria-labelledby="main-title">
 

--- a/src/pages/join.astro
+++ b/src/pages/join.astro
@@ -4,7 +4,6 @@
 // ============================================================================
 import BaseLayout from "../layouts/BaseLayout.astro";
 import ArcCanvas from "../components/ArcCanvas.astro";
-import SiteHeader from "../components/SiteHeader.astro";
 import PageNavigation from "../components/PageNavigation.astro";
 
 // NEW: Import shared components - but use sparingly to preserve design
@@ -30,9 +29,14 @@ const seo = buildSEO({
 });
 ---
 
-<BaseLayout title={seo.title} description={seo.description} bodyClass="page-join" seo={seo}>
-  <ArcCanvas />
-  <SiteHeader active="join" />
+<BaseLayout
+  title={seo.title}
+  description={seo.description}
+  bodyClass="page-join"
+  seo={seo}
+  navActive="join"
+>
+  <ArcCanvas slot="before-header" />
 
   <main id="main-content" class="page-shell" aria-labelledby="join-title">
     

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -10,7 +10,6 @@
 // ============================================================================
 import BaseLayout from "../layouts/BaseLayout.astro";
 import ArcCanvas from "../components/ArcCanvas.astro";
-import SiteHeader from "../components/SiteHeader.astro";
 import PageNavigation from "../components/PageNavigation.astro";
 import Card from "../components/Card.astro";
 import LinkButton from "../components/LinkButton.astro";
@@ -52,9 +51,14 @@ const seo = buildSEO({
 });
 ---
 
-<BaseLayout title={seo.title} description={seo.description} bodyClass="page-projects" seo={seo}>
-  <ArcCanvas />
-  <SiteHeader active="projects" />
+<BaseLayout
+  title={seo.title}
+  description={seo.description}
+  bodyClass="page-projects"
+  seo={seo}
+  navActive="projects"
+>
+  <ArcCanvas slot="before-header" />
 
   <main id="main-content" class="page-shell" aria-labelledby="projects-title">
     

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -11,7 +11,6 @@
 import { getCollection } from 'astro:content';
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import ArcCanvas from "../../components/ArcCanvas.astro";
-import SiteHeader from "../../components/SiteHeader.astro";
 import PageNavigation from "../../components/PageNavigation.astro";
 import Card from "../../components/Card.astro";
 import LinkButton from "../../components/LinkButton.astro";
@@ -49,9 +48,14 @@ const hasContributions = project.data.contributions && project.data.contribution
 const hasLinks = project.data.links && project.data.links.length > 0;
 ---
 
-<BaseLayout title={seo.title} description={seo.description} bodyClass="page-project-detail" seo={seo}>
-  <ArcCanvas />
-  <SiteHeader active="projects" />
+<BaseLayout
+  title={seo.title}
+  description={seo.description}
+  bodyClass="page-project-detail"
+  seo={seo}
+  navActive="projects"
+>
+  <ArcCanvas slot="before-header" />
 
   <main id="main-content" class="page-shell project-detail-shell">
     

--- a/src/pages/template.astro
+++ b/src/pages/template.astro
@@ -1,0 +1,267 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import SectionHeader from "../components/SectionHeader.astro";
+import Card from "../components/Card.astro";
+import LinkButton from "../components/LinkButton.astro";
+import StatusBadge from "../components/StatusBadge.astro";
+import CalloutPanel from "../components/CalloutPanel.astro";
+import SectionDivider from "../components/SectionDivider.astro";
+import "../styles/global.css";
+
+import { withBase } from "../utils/paths";
+import { buildSEO } from "../utils/seo";
+
+const seo = buildSEO({
+  title: "Template Showcase",
+  description: "Layout playground for reviewing ArcUp component combinations.",
+  path: "/template",
+  siteUrl: Astro.site,
+});
+---
+
+<BaseLayout
+  title={seo.title}
+  description={seo.description}
+  bodyClass="page-template"
+  seo={seo}
+  navActive="projects"
+>
+  <main id="main-content" class="page-shell">
+    <nav class="breadcrumb" aria-label="Breadcrumb">
+      <a href={withBase("/")}>Home</a>
+      <span aria-hidden="true">/</span>
+      <span aria-current="page">Template Showcase</span>
+    </nav>
+    <section class="surface-panel">
+      <SectionHeader
+        eyebrow="Template Eyebrow"
+        title="Template Hero Title"
+        subtitle="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+        align="left"
+        headingLevel="h1"
+      />
+
+      <p class="lead">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla facilisi. Integer vitae neque sed urna vestibulum
+        pretium in id risus.
+      </p>
+
+      <div class="hero-actions">
+        <LinkButton href={withBase("/projects")} variant="primary" icon="arrow-right">
+          Primary Action
+        </LinkButton>
+        <LinkButton href={withBase("/about")} variant="outline" icon="arrow-right">
+          Secondary Action
+        </LinkButton>
+        <LinkButton href={withBase("/join")} variant="ghost" icon="arrow-right">
+          Ghost Action
+        </LinkButton>
+      </div>
+    </section>
+
+    <section>
+      <SectionHeader
+        eyebrow="Buttons"
+        title="Button Variations"
+        subtitle="Demonstrates primary, outline, and ghost button styles using the link button component."
+        align="center"
+        headingLevel="h2"
+      />
+
+      <div class="hero-actions">
+        <LinkButton href={withBase("/join")} variant="primary" icon="arrow-right">
+          Primary Button
+        </LinkButton>
+        <LinkButton href={withBase("/projects")} variant="outline" icon="arrow-right">
+          Secondary Button
+        </LinkButton>
+        <LinkButton href={withBase("/how")} variant="ghost" icon="arrow-right">
+          Ghost Button
+        </LinkButton>
+      </div>
+    </section>
+
+    <nav class="home-nav-cards" aria-label="Template navigation cards">
+      <a href={withBase("/about")} class="nav-card">
+        <h3>About Section</h3>
+        <p>Mirrors the homepage navigation cards with arrow reveal on hover.</p>
+        <span class="nav-card-arrow" aria-hidden="true">→</span>
+      </a>
+
+      <a href={withBase("/projects")} class="nav-card">
+        <h3>Projects Section</h3>
+        <p>Shows how the arrow icon animates into view for interactive links.</p>
+        <span class="nav-card-arrow" aria-hidden="true">→</span>
+      </a>
+
+      <a href={withBase("/how")} class="nav-card">
+        <h3>Methods Section</h3>
+        <p>Uses the same home-nav-cards layout for consistency checks.</p>
+        <span class="nav-card-arrow" aria-hidden="true">→</span>
+      </a>
+
+      <a href={withBase("/join")} class="nav-card">
+        <h3>Join Section</h3>
+        <p>Ensures hover arrow behaviour is ready for reuse across pages.</p>
+        <span class="nav-card-arrow" aria-hidden="true">→</span>
+      </a>
+    </nav>
+
+    <SectionDivider variant="subtle" spacing="compact" />
+
+    <section>
+      <SectionHeader
+        eyebrow="Three Column"
+        title="Card Variants"
+        subtitle="Showcases default, surface, outline, and enhanced card content combinations."
+        align="left"
+        headingLevel="h2"
+      />
+
+      <div class="card-grid">
+        <Card variant="default" as="article">
+          <h3>Default Variant</h3>
+          <p>
+            Uses the default background option for scenarios where stronger contrast is preferred against the page
+            surface.
+          </p>
+          <LinkButton href={withBase("/projects")} variant="ghost" icon="arrow-right">
+            Explore Projects
+          </LinkButton>
+        </Card>
+
+        <Card as="article">
+          <span class="eyebrow">Step 01</span>
+          <h3>Numbered Badge</h3>
+          <p>
+            Presents a simple numbered marker using existing typography tokens for outlining sequential steps without
+            extra styling.
+          </p>
+          <LinkButton href={withBase("/how")} variant="ghost" icon="arrow-right">
+            View Process
+          </LinkButton>
+        </Card>
+
+        <Card as="article">
+          <h3>Hover Glow Card</h3>
+          <p>
+            Leverages the built-in hover elevation to communicate interactivity. Move the pointer to observe the glow
+            response.
+          </p>
+          <LinkButton href={withBase("/join")} variant="outline" icon="arrow-right">
+            Interact
+          </LinkButton>
+        </Card>
+      </div>
+    </section>
+
+    <section>
+      <SectionHeader
+        eyebrow="Two Column"
+        title="Card Layout Variations"
+        subtitle="Examples combining status indicators, arrow icons, and alternative padding."
+        align="center"
+        headingLevel="h2"
+      />
+
+      <div class="card-grid">
+        <Card as="article" padding="spacious">
+          <StatusBadge status="active" />
+          <h3>Status Enabled Card</h3>
+          <p>
+            Integrates a status badge component for communicating project state within a content panel.
+          </p>
+          <LinkButton href={withBase("/projects")} icon="arrow-right">
+            Open Project
+          </LinkButton>
+        </Card>
+
+        <Card as="article" variant="outline" hover={false} padding="compact">
+          <h3>Arrow Icon CTA</h3>
+          <p>
+            Demonstrates an outline treatment with the arrow icon enabled on the action link for directional emphasis.
+          </p>
+          <LinkButton href={withBase("/about")} variant="primary" icon="arrow-right">
+            Learn About Us
+          </LinkButton>
+        </Card>
+      </div>
+    </section>
+
+    <section>
+      <SectionHeader
+        eyebrow="Raw Class Example"
+        title="Manual Card Markup"
+        subtitle="Demonstrates direct use of the card utility classes without the Card component wrapper."
+        align="left"
+        headingLevel="h2"
+      />
+
+      <div class="card-grid">
+        <div class="card card--surface card--padding-spacious card--hover">
+          <h3>Utility Class Card</h3>
+          <p>
+            This panel uses the combined class string <code>card card--surface card--padding-spacious card--hover</code> to
+            match legacy implementations that render cards without the component abstraction.
+          </p>
+          <a class="link-button link-button--outline" href={withBase("/projects")}>
+            Review Legacy Usage
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <section class="surface-panel">
+      <SectionHeader
+        eyebrow="Callouts"
+        title="Callout Panel Example"
+        subtitle="Use callouts to highlight important notices, warnings, or quick reference summaries."
+        align="left"
+        headingLevel="h2"
+      />
+
+      <CalloutPanel variant="info" icon="💡" title="Helpful Context">
+        <p>
+          Callout panels inherit global spacing tokens and surface treatments, making them ideal for emphasising compact
+          notes without bespoke styling.
+        </p>
+      </CalloutPanel>
+    </section>
+
+    <section class="acknowledgements-section">
+      <SectionHeader
+        eyebrow="Acknowledgements"
+        title="Hybrid Grid Placeholder"
+        subtitle="Structure mirrors the acknowledgements section so upcoming CSS can be validated."
+        align="left"
+        headingLevel="h2"
+      />
+
+      <div class="acknowledgements-intro">
+        <p><strong>Placeholder copy:</strong> Introduce the collaborators or communities being recognised.</p>
+      </div>
+
+      <div class="acknowledgements-grid">
+        <article class="acknowledgement-card">
+          <h3>Placeholder Item One</h3>
+          <p>Space reserved for name, link, or description content.</p>
+        </article>
+
+        <article class="acknowledgement-card">
+          <h3>Placeholder Item Two</h3>
+          <p>Use this block to verify hybrid grid alignments.</p>
+        </article>
+
+        <article class="acknowledgement-card">
+          <h3>Placeholder Item Three</h3>
+          <p>Helps confirm typography and spacing tokens once styles merge.</p>
+        </article>
+
+        <article class="acknowledgement-card">
+          <h3>Placeholder Item Four</h3>
+          <p>Ensures multi-column responsiveness for mixed content.</p>
+        </article>
+      </div>
+    </section>
+  </main>
+</BaseLayout>

--- a/src/pages/test.astro
+++ b/src/pages/test.astro
@@ -16,7 +16,6 @@
 
 import BaseLayout from "../layouts/BaseLayout.astro";
 import ArcCanvas from "../components/ArcCanvas.astro";
-import SiteHeader from "../components/SiteHeader.astro";
 import PageNavigation from "../components/PageNavigation.astro";
 import SectionHeader from "../components/SectionHeader.astro";
 import SectionDivider from "../components/SectionDivider.astro";
@@ -37,9 +36,14 @@ const seo = buildSEO({
 });
 ---
 
-<BaseLayout title={seo.title} description={seo.description} seo={seo} bodyClass="page-generic">
-  <ArcCanvas />
-  <SiteHeader active="page" />
+<BaseLayout
+  title={seo.title}
+  description={seo.description}
+  seo={seo}
+  bodyClass="page-generic"
+  navActive="home"
+>
+  <ArcCanvas slot="before-header" />
 
   <main id="main-content" class="page-shell" aria-labelledby="page-title">
 


### PR DESCRIPTION
## Summary
- render the global SiteHeader from BaseLayout with optional pre-header slot support
- update all pages to pass navActive, move ArcCanvas into the pre-header slot, and remove per-page header imports
- add a breadcrumb preview and nav highlight state on template.astro for visual review

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e64aa0444c8330be79d06843f1dcac