### PR TITLE
Annotate page templates with structural comments

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -29,7 +29,7 @@ const seo = buildSEO({
 
   <main id="main-content" class="page-shell" aria-labelledby="page-title">
 
-    <!-- HERO SECTION -->
+    <!-- HERO SECTION: Page introduction outlining ArcUp's mission and context -->
     <header class="page-hero" aria-labelledby="page-title">
       <p class="eyebrow">re:practising science & innovation</p>
       <h1 id="page-title">About ArcUp</h1>
@@ -39,6 +39,7 @@ const seo = buildSEO({
       </p>
     </header>
 
+    <!-- SECTION: Overview of ArcUp's focus areas -->
     <section class="page-section" aria-labelledby="section-1-title">
     <SectionHeader
         title="Our Focus"
@@ -47,8 +48,10 @@ const seo = buildSEO({
 
         />
 
+    <!-- GRID: Two-card layout summarizing structure and purpose pillars -->
     <div class="card-grid">
 
+        <!-- CARD: Structure theme highlighting open design -->
         <Card as="article" variant="surface">
         <h3>Structure: Open by Design</h3>
         <p>
@@ -62,6 +65,7 @@ const seo = buildSEO({
         </p>
         </Card>
 
+        <!-- CARD: Purpose theme focusing on regenerative practice -->
         <Card as="article" variant="surface">
         <h3>Purpose: Regeneration as Practice</h3>
         <p>
@@ -77,23 +81,27 @@ const seo = buildSEO({
     </section>
 
 
-    <!-- SECTION 2 -->
+    <!-- SECTION: Navigation to deeper About subpages -->
     <section class="page-section" aria-labelledby="section-2-title">
       <SectionHeader
         title="What You’ll Find Here"
         subtitle="Learn the story, people, and purpose behind ArcUp."
       />
+      <!-- GRID: Three-card menu linking to Origin, Founder, and Mission pages -->
       <div class="card-grid">
+        <!-- CARD: Link to Origin story -->
         <Card as="article" class="info-card">
           <h3>Origin</h3>
           <p>How a small plasma–seed experiment became a framework for regenerative research.</p>
           <LinkButton href={withBase('/about/origin')} variant="outline" icon="arrow-right">Read the Story</LinkButton>
         </Card>
+        <!-- CARD: Link to Founder profile -->
         <Card as="article" class="info-card">
           <h3>Founder</h3>
           <p>Meet Ali Saleh and the systems thinking shaping ArcUp’s interdisciplinary approach.</p>
           <LinkButton href={withBase('/about/founder')} variant="outline" icon="arrow-right">Meet Ali</LinkButton>
         </Card>
+        <!-- CARD: Link to Mission overview -->
         <Card as="article" class="info-card">
           <h3>Mission</h3>
           <p>Discover the vision, phases, and long-term goal of a commons for plasma research.</p>
@@ -102,7 +110,7 @@ const seo = buildSEO({
       </div>
     </section>
 
-    <!-- CTA FOOTER -->
+    <!-- CTA SECTION: Invitation to participate and connect -->
     <section class="cta-section" aria-labelledby="cta-title">
       <SectionHeader
         title="Be Part of the Work"

--- a/src/pages/about/founder.astro
+++ b/src/pages/about/founder.astro
@@ -35,20 +35,20 @@ const seo = buildSEO({
 
   <main id="main-content" class="page-shell" aria-labelledby="founder-title">
     
-    <!-- Breadcrumb -->
+    <!-- BREADCRUMB: Contextual navigation back to About hub -->
     <nav class="breadcrumb" aria-label="Breadcrumb" style="display: flex; align-items: center; gap: 0.5rem; font-size: 0.9rem; color: var(--color-text-muted); padding: 1rem 0 0 0;">
       <a href={withBase("/about")} style="color: var(--color-primary-bright); text-decoration: none;">About</a>
       <span aria-hidden="true">/</span>
       <span aria-current="page">Founder</span>
     </nav>
 
-    <!-- HERO SECTION -->
+    <!-- HERO SECTION: Introduces founder and mission-driven perspective -->
     <header class="about-hero" aria-labelledby="founder-title">
       <h1 id="founder-title">Meet Ali</h1>
       <p class="lead">A student, tinkerer, and systems thinker trying to build technology that <em>serves life</em> instead of extracting from it.</p>
     </header>
 
-    <!-- INTRODUCTION -->
+    <!-- SECTION: Personal background and interdisciplinary roots -->
     <section>
       <Card>
         <div class="about-content">
@@ -63,7 +63,7 @@ const seo = buildSEO({
       </Card>
     </section>
 
-    <!-- BUILDING ARC^ -->
+    <!-- SECTION: Origin story of ArcUp experiments -->
     <section>
       <Card>
         <div class="about-content">
@@ -72,6 +72,7 @@ const seo = buildSEO({
             align="left"
             headingLevel="h2"
           />
+          <!-- STORY BLOCK: Early experiments with plasma-treated water -->
           <p>My first experiments were small: plasma discharges across glass electrodes, powered by flyback transformers and a Z-driver circuit. I was testing how plasma-treated water might affect seed germination — and it did.</p>
           <p>Watching seeds respond to plasma sparked a question that changed everything:</p>
           <p style="margin: 1.5rem 0; padding: 1.5rem; background: rgba(10, 147, 150, 0.08); border-left: 3px solid var(--color-primary-bright); border-radius: var(--radius-sm); font-style: italic; color: var(--color-text); text-align: center;"><em>What would it look like if this was built in the open?</em></p>
@@ -80,7 +81,7 @@ const seo = buildSEO({
       </Card>
     </section>
 
-    <!-- SYSTEMS VIEW -->
+    <!-- SECTION: Systems-thinking perspective -->
     <section>
       <Card>
         <div class="about-content">
@@ -89,6 +90,7 @@ const seo = buildSEO({
             align="left"
             headingLevel="h2"
           />
+          <!-- TEXT BLOCK: Integrating disciplines and ethics -->
           <p>I've always been drawn to how systems interconnect — ecological, technological, social. Through arc^, I'm exploring how plasma, data, and design can <em>support living systems</em> rather than extract from them.</p>
           <p>This is why arc^ stays interdisciplinary: it sits between biology, physics, ethics, and culture, and invites each field to inform the others.</p>
           <p style="font-weight: 500; color: var(--color-text); margin-top: 1.5rem; padding-top: 1.5rem; border-top: 1px solid var(--color-border); font-style: italic;">Science is strongest when it listens — to ecosystems, to people, to context.</p>
@@ -96,7 +98,7 @@ const seo = buildSEO({
       </Card>
     </section>
 
-    <!-- PERSONAL ETHOS -->
+    <!-- SECTION: Personal ethos statements -->
     <section>
       <Card variant="outline">
         <div class="about-content">
@@ -105,6 +107,7 @@ const seo = buildSEO({
             align="left"
             headingLevel="h2"
           />
+          <!-- TEXT BLOCK: Values guiding founder -->
           <p style="font-size: clamp(1.1rem, 2.5vw, 1.2rem); font-style: italic; color: var(--color-text);">For me, arc^ isn't a project — it's a way of doing research differently.</p>
           <p style="font-size: clamp(1.1rem, 2.5vw, 1.2rem); font-style: italic; color: var(--color-text);">One that values <em>openness over ownership</em>, <em>curiosity over control</em>, and <em>regeneration over recognition</em>.</p>
           <p style="margin-top: 1.5rem; padding-top: 1.5rem; border-top: 1px solid var(--color-border);">I believe the best science is that which serves — restoring balance between innovation and the living world that sustains it.</p>
@@ -112,7 +115,7 @@ const seo = buildSEO({
       </Card>
     </section>
 
-    <!-- LOOKING FORWARD -->
+    <!-- SECTION: Future vision and stewardship -->
     <section>
       <Card>
         <div class="about-content">
@@ -121,6 +124,7 @@ const seo = buildSEO({
             align="left"
             headingLevel="h2"
           />
+          <!-- TEXT BLOCK: Invitation for shared ownership -->
           <p>arc^ is still young — an evolving commons that anyone aligned with its purpose can join.</p>
           <p>My role is to hold the space: to guide its early shape, document openly, and build the ethical scaffolding that will let others expand it further.</p>
           <p style="font-weight: 500; color: var(--color-text); margin-top: 1.5rem; padding-top: 1.5rem; border-top: 1px solid var(--color-border);"><em>arc^ isn't mine alone — it's ours to grow, together.</em></p>
@@ -128,7 +132,7 @@ const seo = buildSEO({
       </Card>
     </section>
 
-    <!-- CONNECT -->
+    <!-- SECTION: Calls to connect with founder and join arc^ -->
     <section class="about-callout">
       <Card variant="outline">
         <div class="about-content">
@@ -137,17 +141,18 @@ const seo = buildSEO({
             align="center"
             headingLevel="h2"
           />
+          <!-- CTA GROUP: External site and join page -->
           <p>Want to learn more about my broader work in ecology, technology, and systems thinking?</p>
           <div class="about-actions">
-            <LinkButton 
+            <LinkButton
               href={EXTERNAL_LINKS.personalSite}
               variant="outline"
               icon="external"
             >
               Visit xbyali.page
             </LinkButton>
-            <LinkButton 
-              href={withBase("/join")} 
+            <LinkButton
+              href={withBase("/join")}
               variant="primary"
               icon="arrow-right"
             >
@@ -158,11 +163,11 @@ const seo = buildSEO({
       </Card>
     </section>
 
-    <!-- NAVIGATION -->
+    <!-- SECTION: Secondary navigation back to About overview -->
     <section class="about-callout">
       <div class="about-actions">
-        <LinkButton 
-          href={withBase("/about")} 
+        <LinkButton
+          href={withBase("/about")}
           variant="outline"
         >
           ← Back to About

--- a/src/pages/about/mission.astro
+++ b/src/pages/about/mission.astro
@@ -22,19 +22,19 @@ const seo = buildSEO({
 >
   <main id="main-content" class="page-shell page-mission">
     
-    <!-- Breadcrumb -->
+    <!-- BREADCRUMB: Locates mission page within About hierarchy -->
     <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href={withBase("/about")}>About</a>
       <span aria-hidden="true">/</span>
       <span aria-current="page">Mission</span>
     </nav>
 
-    <!-- Hero -->
+    <!-- HERO SECTION: States overarching mission question -->
     <header class="mission-hero">
       <h1>Why ArcUp Exists</h1>
     </header>
 
-    <!-- Purpose -->
+    <!-- SECTION: Defines purpose and guiding values -->
     <section class="mission-section">
       <h2 aria-label="ArcUp mission statement and purpose">The Purpose</h2>
       <p>
@@ -49,7 +49,7 @@ const seo = buildSEO({
       </p>
     </section>
 
-    <!-- For the Many -->
+    <!-- SECTION: Emphasizes inclusive, regenerative mission -->
     <Card as="section" class="many-section">
       <h2 aria-label="ArcUp's ethical alignment and inclusivity">For the Many, Not the Few</h2>
       <p>
@@ -60,31 +60,35 @@ const seo = buildSEO({
         communities, our ecosystems, and our shared humanity.
       </p>
       <p>
-        Our mission is to make plasma research accessible across disciplines — bridging engineers, biologists, artists, 
+        Our mission is to make plasma research accessible across disciplines — bridging engineers, biologists, artists,
         and institutions — so that ecological restoration becomes a shared, global experiment.
       </p>
     </Card>
 
-    <!-- Name Meaning -->
+    <!-- SECTION: Breaks down meaning of the name arc^ -->
     <section class="name-section">
       <h2 aria-label="Meaning and symbolism of the name arc^">Meaning of the Name — arc<span class="caret">^</span></h2>
       <p class="name-intro">
         The name carries three intertwined meanings:
       </p>
 
+      <!-- GRID: Three interpretations of the name -->
       <div class="name-meanings">
+        <!-- CARD: Rising in defense interpretation -->
         <Card as="article" class="meaning-card">
           <div class="meaning-symbol">↑</div>
           <h3>"to arc up"</h3>
           <p>to rise in defense of people and planet</p>
         </Card>
 
+        <!-- CARD: Power notation interpretation -->
         <Card as="article" class="meaning-card">
           <div class="meaning-symbol">^</div>
           <h3>"^ to the power of"</h3>
           <p>representing amplification through shared knowledge</p>
         </Card>
 
+        <!-- CARD: Plasma arc metaphor -->
         <Card as="article" class="meaning-card">
           <div class="meaning-symbol">⚡</div>
           <h3>"plasma arc"</h3>
@@ -92,6 +96,7 @@ const seo = buildSEO({
         </Card>
       </div>
 
+      <!-- EQUATION: Summarizes symbolic formula -->
       <div class="name-equation">
         <p class="equation-text">
           arc<span class="caret">^</span> = resistance × regeneration × plasma energy
@@ -102,12 +107,14 @@ const seo = buildSEO({
       </div>
     </section>
 
-    <!-- Phases -->
+    <!-- SECTION: Outlines phased roadmap for ArcUp -->
     <section class="phases-section">
       <h2 aria-label="ArcUp phased development model">The ArcUp Phases — From Spark to Commons</h2>
 
+      <!-- GRID: Three-phase development journey -->
       <div class="phases-grid">
-        
+
+        <!-- CARD: Phase 1 details -->
         <Card as="article" class="phase-card">
           <div class="phase-icon">🌱</div>
           <h3>Phase 1 — Bench-Scale, Open Experiments</h3>
@@ -116,7 +123,7 @@ const seo = buildSEO({
               Hands-on exploration using dielectric barrier discharge (DBD) setups — simple, accessible, off-the-shelf components.
             </p>
             <p>
-              We test plasma-water interactions for purification, agriculture, and ecological applications, sharing results 
+              We test plasma-water interactions for purification, agriculture, and ecological applications, sharing results
               openly so others can replicate and improve them.
             </p>
             <p class="phase-outcome">
@@ -125,6 +132,7 @@ const seo = buildSEO({
           </div>
         </Card>
 
+        <!-- CARD: Phase 2 details -->
         <Card as="article" class="phase-card">
           <div class="phase-icon">🌍</div>
           <h3>Phase 2 — Community Prototyping Framework</h3>
@@ -133,22 +141,23 @@ const seo = buildSEO({
               As results mature, we develop shared templates — community-ready DBD frameworks and build guides.
             </p>
             <p>
-              The goal is to form a commons of plasma tools where data, blueprints, and safety notes circulate openly yet 
+              The goal is to form a commons of plasma tools where data, blueprints, and safety notes circulate openly yet
               responsibly, ensuring variants remain traceable and free from enclosure.
             </p>
           </div>
         </Card>
 
+        <!-- CARD: Phase 3 details -->
         <Card as="article" class="phase-card">
           <div class="phase-icon">🔭</div>
           <h3>Phase 3 — Collaborative Application</h3>
           <div class="phase-content">
             <p>
-              When the work reaches maturity, interdisciplinary teams and institutions can collaborate to apply plasma 
+              When the work reaches maturity, interdisciplinary teams and institutions can collaborate to apply plasma
               systems in real-world ecological contexts.
             </p>
             <p>
-              At this stage, governance matters: defensive openness replaces property. ArcUp invites collective custodianship, 
+              At this stage, governance matters: defensive openness replaces property. ArcUp invites collective custodianship,
               ensuring that no discovery becomes privately locked down and that all benefit flows back to the commons.
             </p>
           </div>
@@ -157,17 +166,18 @@ const seo = buildSEO({
       </div>
     </section>
 
-    <!-- Vision -->
+    <!-- SECTION: Concluding vision and key principles -->
     <Card as="section" class="vision-section">
       <h2 aria-label="ArcUp broader mission and closing reflection">The Broader Vision</h2>
       <p>
-        ArcUp's mission is to create a living backbone for open plasma research — one that connects independent experimenters, 
+        ArcUp's mission is to create a living backbone for open plasma research — one that connects independent experimenters,
         academic labs, and communities across borders.
       </p>
       <p>
-        We're building a space where knowledge moves freely between art, science, and culture — where technology can once 
+        We're building a space where knowledge moves freely between art, science, and culture — where technology can once
         again serve <em>life</em>.
       </p>
+      <!-- LIST: Core commitments that anchor vision -->
       <div class="vision-principles">
         <p>No property locked down.</p>
         <p>No gatekeeping of discovery.</p>
@@ -175,11 +185,11 @@ const seo = buildSEO({
       </div>
     </Card>
 
-    <!-- CTA to Repractice -->
+    <!-- CTA SECTION: Direct link to methodology for deeper context -->
     <div class="repractice-cta">
       <p>Want to understand the ethical foundation?</p>
-      <LinkButton 
-        href={withBase("/how")} 
+      <LinkButton
+        href={withBase("/how")}
         variant="primary"
         icon="arrow-right"
       >
@@ -187,10 +197,10 @@ const seo = buildSEO({
       </LinkButton>
     </div>
 
-    <!-- Navigation -->
+    <!-- NAVIGATION: Links to related About resources -->
     <nav class="mission-nav" aria-label="Continue exploring">
-      <LinkButton 
-        href={withBase("/about/founder")} 
+      <LinkButton
+        href={withBase("/about/founder")}
         variant="outline"
         icon="arrow-right"
       >

--- a/src/pages/about/origin.astro
+++ b/src/pages/about/origin.astro
@@ -22,19 +22,19 @@ const seo = buildSEO({
 >
   <main id="main-content" class="page-shell page-origin">
     
-    <!-- Breadcrumb -->
+    <!-- BREADCRUMB: Indicates position within About section -->
     <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href={withBase("/about")}>About</a>
       <span aria-hidden="true">/</span>
       <span aria-current="page">Origin</span>
     </nav>
 
-    <!-- Hero -->
+    <!-- HERO SECTION: Sets tone for origin story -->
     <header class="origin-hero">
       <h1>How ArcUp Began</h1>
     </header>
 
-    <!-- The Question -->
+    <!-- SECTION: Foundational question that inspired ArcUp -->
     <section class="origin-section">
       <h2 aria-label="Introduction: The question that inspired ArcUp">A Question That Started It All</h2>
       <p class="origin-question">
@@ -50,12 +50,12 @@ const seo = buildSEO({
       </p>
     </section>
 
-    <!-- Early Experiments -->
+    <!-- SECTION: Early experiments illustrating first successes -->
     <Card as="section" class="experiments-section">
       <h2 aria-label="ArcUp early experiments with plasma and seed germination">Early Experiments — The First Spark</h2>
       <div class="experiments-content">
         <p>
-          ArcUp began in a small room with a flyback transformer, a driver circuit, and a few glass electrodes. 
+          ArcUp began in a small room with a flyback transformer, a driver circuit, and a few glass electrodes.
           I had been reading plasma research papers from around the world — seeing how different teams were exploring 
           plasma-water interactions — and decided to test it for myself.
         </p>
@@ -75,13 +75,14 @@ const seo = buildSEO({
       </div>
     </Card>
 
-    <!-- The Pattern -->
+    <!-- SECTION: Systemic pattern ArcUp challenges -->
     <section class="pattern-section">
       <h2 aria-label="The systemic issues ArcUp responds to">The Pattern We Refuse</h2>
       <p>
         Looking back across centuries, I saw a cycle repeating:
       </p>
-      
+
+      <!-- DIAGRAM: Visualizes cycle of extraction -->
       <div class="pattern-cycle">
         <div class="cycle-item">Conflict</div>
         <div class="cycle-arrow">→</div>
@@ -100,6 +101,7 @@ const seo = buildSEO({
         A pattern of extraction dressed up as progress.
       </p>
 
+      <!-- CALLOUT CARD: Lists contemporary manifestations -->
       <Card class="pattern-today">
         <h3>Today it looks like this:</h3>
         <ul class="pattern-list">
@@ -110,6 +112,7 @@ const seo = buildSEO({
         </ul>
       </Card>
 
+      <!-- TEXT BLOCK: Response framing -->
       <div class="pattern-response">
         <p>
           ArcUp was born from a refusal of that pattern. It's not rebellion for its own sake — it's a reorientation.
@@ -120,17 +123,18 @@ const seo = buildSEO({
       </div>
     </section>
 
-    <!-- Framework -->
+    <!-- SECTION: Transition from experiment to shared framework -->
     <Card as="section" class="framework-origin-section">
       <h2 aria-label="Transition from individual experiment to open framework">A Framework, Not a Lab</h2>
       <p>
-        ArcUp grew from this reflection into a framework — a set of methods, values, and open tools for regenerative 
-        plasma research. It integrates my background in ecology, computer science, and systems thinking, but sits 
+        ArcUp grew from this reflection into a framework — a set of methods, values, and open tools for regenerative
+        plasma research. It integrates my background in ecology, computer science, and systems thinking, but sits
         outside the usual institutions that govern innovation.
       </p>
       <p>
         It's science re-practised — built to serve <em>life</em>, not ownership.
       </p>
+      <!-- CLOSING STATEMENTS: Invitation to collaborate -->
       <div class="framework-closing">
         <p>
           Arc^ began as one person's experiment.
@@ -141,10 +145,10 @@ const seo = buildSEO({
       </div>
     </Card>
 
-    <!-- Navigation -->
+    <!-- NAVIGATION: Links to related About subpages -->
     <nav class="origin-nav" aria-label="Continue exploring">
-      <LinkButton 
-        href={withBase("/about/founder")} 
+      <LinkButton
+        href={withBase("/about/founder")}
         variant="primary"
         icon="arrow-right"
       >

--- a/src/pages/draft/about.astro
+++ b/src/pages/draft/about.astro
@@ -32,7 +32,7 @@ const seo = buildSEO({
 
   <main id="main-content" class="page-shell" aria-labelledby="page-title">
 
-    <!-- HERO SECTION -->
+    <!-- HERO SECTION: Draft overview of ArcUp purpose -->
     <header class="page-hero" aria-labelledby="page-title">
       <p class="eyebrow">re:practising science & innovation</p>
       <h1 id="page-title">About ArcUp</h1>
@@ -42,6 +42,7 @@ const seo = buildSEO({
       </p>
     </header>
 
+    <!-- SECTION: Draft focus overview cards -->
     <section class="page-section" aria-labelledby="section-1-title">
     <SectionHeader
         title="Our Focus"
@@ -50,8 +51,10 @@ const seo = buildSEO({
 
         />
 
+    <!-- GRID: Dual-card breakdown of structure and purpose themes -->
     <div class="card-grid">
 
+        <!-- CARD: Structure emphasis -->
         <Card as="article" variant="surface">
         <h3>Structure: Open by Design</h3>
         <p>     <!-- can we get this colour muted -->
@@ -65,6 +68,7 @@ const seo = buildSEO({
         </p>
         </Card>
 
+        <!-- CARD: Purpose emphasis -->
         <Card as="article" variant="surface">
         <h3>Purpose: Regeneration as Practice</h3>
         <p><!-- can we get this colour muted -->
@@ -80,23 +84,27 @@ const seo = buildSEO({
     </section>
 
 
-    <!-- SECTION 2 -->
+    <!-- SECTION: Draft navigation cards to subpages -->
     <section class="page-section" aria-labelledby="section-2-title">
       <SectionHeader
         title="What You’ll Find Here"
         subtitle="Learn the story, people, and purpose behind ArcUp."
       />
+      <!-- GRID: Links to Origin, Founder, and Mission drafts -->
       <div class="card-grid">
+        <!-- CARD: Origin draft link -->
         <Card as="article" class="info-card">
           <h3>Origin</h3>
           <p>How a small plasma–seed experiment became a framework for regenerative research.</p>
           <LinkButton href={withBase('/about/origin')} variant="outline" icon="arrow-right">Read the Story</LinkButton>
         </Card>
+        <!-- CARD: Founder draft link -->
         <Card as="article" class="info-card">
           <h3>Founder</h3>
           <p>Meet Ali Saleh and the systems thinking shaping ArcUp’s interdisciplinary approach.</p>
           <LinkButton href={withBase('/about/founder')} variant="outline" icon="arrow-right">Meet Ali</LinkButton>
         </Card>
+        <!-- CARD: Mission draft link -->
         <Card as="article" class="info-card">
           <h3>Mission</h3>
           <p>Discover the vision, phases, and long-term goal of a commons for plasma research.</p>
@@ -105,7 +113,7 @@ const seo = buildSEO({
       </div>
     </section>
 
-    <!-- CTA FOOTER -->
+    <!-- CTA SECTION: Draft invite to engage and follow workspace -->
     <section class="cta-section" aria-labelledby="cta-title">
       <SectionHeader
         title="Be Part of the Work"

--- a/src/pages/draft/founder.astro
+++ b/src/pages/draft/founder.astro
@@ -42,7 +42,7 @@ const seo = buildSEO({
   <main id="main-content" class="page-shell" aria-labelledby="page-title">
 
     <!-- ================================================================ -->
-    <!-- HERO -->
+    <!-- HERO SECTION: Draft introduction to Ali Saleh -->
     <!-- ================================================================ -->
     <header class="page-hero" aria-labelledby="page-title">
       <p class="eyebrow">About / Founder</p>
@@ -58,7 +58,7 @@ const seo = buildSEO({
     <SectionDivider variant="subtle" spacing="compact" />
 
     <!-- ================================================================ -->
-    <!-- SECTION 1 — Background -->
+    <!-- SECTION: Background narrative and learning philosophy -->
     <!-- ================================================================ -->
     <section class="page-section" aria-labelledby="background-title">
       <SectionHeader
@@ -68,17 +68,18 @@ const seo = buildSEO({
       />
 
       <p>
-        I’m an undergraduate bioscience student based in Melbourne, Australia.  
-        My path crosses disciplines — from pollution degradation using triboelectric nanogenerators 
+        I’m an undergraduate bioscience student based in Melbourne, Australia.
+        My path crosses disciplines — from pollution degradation using triboelectric nanogenerators
         to restoration ecology and earlier studies in computer science.
       </p>
 
       <p>
-        I’m not a physicist or an engineer by training.  
-        I’m learning as I go, figuring things out in public, and using ArcUp 
+        I’m not a physicist or an engineer by training.
+        I’m learning as I go, figuring things out in public, and using ArcUp
         to explore how ethics, technology, and ecology can be woven into one open practice.
       </p>
 
+      <!-- CALLOUT: Highlights learn-in-public ethos -->
       <CalloutPanel variant="info" icon="🪴" title="Learning in Public">
         <p>
           Every experiment, success, and mistake is documented openly — because science grows stronger when everyone can see the process.
@@ -89,7 +90,7 @@ const seo = buildSEO({
     <SectionDivider variant="default" spacing="normal" />
 
     <!-- ================================================================ -->
-    <!-- SECTION 2 — Systems View -->
+    <!-- SECTION: Systems-level perspective on ArcUp -->
     <!-- ================================================================ -->
     <section class="page-section" aria-labelledby="systems-title">
       <SectionHeader
@@ -99,17 +100,20 @@ const seo = buildSEO({
       />
 
       <p>
-        I’ve always been drawn to how systems interconnect — biological, technological, and social.  
+        I’ve always been drawn to how systems interconnect — biological, technological, and social.
         Through ArcUp, I explore how plasma, data, and design can support living systems rather than extract from them.
       </p>
 
+      <!-- GRID: Supporting perspective cards -->
       <div class="card-grid">
+        <!-- CARD: Interdisciplinary practice -->
         <Card as="article" variant="surface">
           <h3>Interdisciplinary Practice</h3>
           <p>
             ArcUp sits between biology, physics, ethics, and design — inviting each field to inform the others.
           </p>
         </Card>
+        <!-- CARD: Ecological thinking -->
         <Card as="article" variant="outline">
           <h3>Ecological Thinking</h3>
           <p>
@@ -126,7 +130,7 @@ const seo = buildSEO({
     <SectionDivider variant="strong" spacing="normal" />
 
     <!-- ================================================================ -->
-    <!-- SECTION 3 — Personal Ethos -->
+    <!-- SECTION: Personal ethos principles -->
     <!-- ================================================================ -->
     <section class="page-section" aria-labelledby="ethos-title">
       <SectionHeader
@@ -135,19 +139,23 @@ const seo = buildSEO({
         align="center"
       />
 
+      <!-- GRID: Value statements cards -->
       <div class="card-grid">
+        <!-- CARD: Openness value -->
         <Card as="article" variant="outline">
           <h3>Openness over Ownership</h3>
           <p>
             Knowledge belongs in the commons — science should circulate, not accumulate.
           </p>
         </Card>
+        <!-- CARD: Curiosity value -->
         <Card as="article" variant="outline">
           <h3>Curiosity over Control</h3>
           <p>
             I approach research as an act of humility — a conversation with the unknown.
           </p>
         </Card>
+        <!-- CARD: Regeneration value -->
         <Card as="article" variant="outline">
           <h3>Regeneration over Recognition</h3>
           <p>
@@ -160,7 +168,7 @@ const seo = buildSEO({
     <SectionDivider variant="subtle" spacing="spacious" />
 
     <!-- ================================================================ -->
-    <!-- SECTION 4 — Looking Forward -->
+    <!-- SECTION: Future vision and stewardship role -->
     <!-- ================================================================ -->
     <section class="page-section" aria-labelledby="future-title">
       <SectionHeader
@@ -182,7 +190,7 @@ const seo = buildSEO({
     <SectionDivider variant="strong" spacing="compact" />
 
     <!-- ================================================================ -->
-    <!-- SECTION 5 — Final CTA -->
+    <!-- SECTION: Final call to connect and collaborate -->
     <!-- ================================================================ -->
     <Card as="section" class="final-cta" variant="surface" padding="spacious">
       <SectionHeader title="Connect & Collaborate" align="center" headingLevel="h2" />
@@ -190,6 +198,7 @@ const seo = buildSEO({
         Want to learn more about my broader work in ecology, technology, and systems thinking?
       </p>
 
+      <!-- CTA GROUP: External site and join link -->
       <div class="button-wrapper">
         <LinkButton href="https://xbyali.page" variant="primary" icon="external">
           Visit xbyali.page
@@ -200,12 +209,12 @@ const seo = buildSEO({
       </div>
 
       <p class="final-note">
-        You can also explore ArcUp’s <a href={withBase("/about/origin")}>origin story</a> or read 
+        You can also explore ArcUp’s <a href={withBase("/about/origin")}>origin story</a> or read
         <a href={withBase("/about/mission")}>our mission</a> next.
       </p>
     </Card>
   <!-- ================================================================ -->
-    <!-- SECTION 4 — The ArcUp Phases -->
+    <!-- SECTION: Outline of ArcUp development phases -->
     <!-- ================================================================ -->
     <section class="page-section" aria-labelledby="phases-title">
       <SectionHeader
@@ -214,35 +223,40 @@ const seo = buildSEO({
         align="center"
       />
 
+      <!-- GRID: Phase roadmap cards -->
       <div class="card-grid">
+        <!-- CARD: Phase 1 summary -->
         <Card as="article" variant="surface">
           <h3>🌱 Phase 1 — Bench-Scale Experiments</h3>
           <p>
-            Simple dielectric barrier discharge (DBD) setups test plasma–water interactions for purification, agriculture, 
+            Simple dielectric barrier discharge (DBD) setups test plasma–water interactions for purification, agriculture,
             and ecological applications. All results are shared openly to build a transparent foundation of reproducible research.
           </p>
         </Card>
 
+        <!-- CARD: Phase 2 summary -->
         <Card as="article" variant="surface">
           <h3>🌍 Phase 2 — Community Prototyping</h3>
           <p>
-            Shared templates and build guides evolve from open data.  
+            Shared templates and build guides evolve from open data.
             This phase builds a commons of plasma tools where knowledge circulates responsibly and safely.
           </p>
         </Card>
 
+        <!-- CARD: Phase 3 summary -->
         <Card as="article" variant="surface">
           <h3>🔭 Phase 3 — Collaborative Application</h3>
           <p>
-            Interdisciplinary teams and institutions co-develop plasma systems in real-world contexts.  
+            Interdisciplinary teams and institutions co-develop plasma systems in real-world contexts.
             Governance shifts from ownership to custodianship — ensuring discoveries remain open for all.
           </p>
         </Card>
       </div>
 
+      <!-- CALLOUT: Emphasizes participation over products -->
       <CalloutPanel variant="neutral" icon="🧭" title="Our Direction">
         <p>
-          ArcUp’s progress isn’t measured by products but by participation — 
+          ArcUp’s progress isn’t measured by products but by participation —
           by how widely knowledge and responsibility are shared.
         </p>
       </CalloutPanel>

--- a/src/pages/draft/mission.astro
+++ b/src/pages/draft/mission.astro
@@ -41,7 +41,7 @@ const seo = buildSEO({
   <main id="main-content" class="page-shell" aria-labelledby="page-title">
 
     <!-- ================================================================ -->
-    <!-- HERO -->
+    <!-- HERO SECTION: Draft framing of ArcUp mission statement -->
     <!-- ================================================================ -->
     <header class="page-hero" aria-labelledby="page-title">
       <p class="eyebrow">About / Mission</p>
@@ -58,7 +58,7 @@ const seo = buildSEO({
     <SectionDivider variant="subtle" spacing="compact" />
 
     <!-- ================================================================ -->
-    <!-- SECTION 1 — Purpose -->
+    <!-- SECTION: Purpose narrative and guiding ethos -->
     <!-- ================================================================ -->
     <section class="page-section" aria-labelledby="purpose-title">
       <SectionHeader
@@ -68,14 +68,15 @@ const seo = buildSEO({
       />
 
       <p>
-        We’re not creating products. We’re cultivating processes — transparent, interdisciplinary, 
-        and rooted in reciprocity. ArcUp began as a single experiment and grew into a collective method: 
+        We’re not creating products. We’re cultivating processes — transparent, interdisciplinary,
+        and rooted in reciprocity. ArcUp began as a single experiment and grew into a collective method:
         a framework for open, regenerative research.
       </p>
 
+      <!-- CALLOUT: Summarizes mission ethos -->
       <CalloutPanel variant="info" icon="🌱" title="Guiding Ethos">
         <p>
-          Every experiment is an act of care.  
+          Every experiment is an act of care.
           Every circuit and dataset is a gesture toward healing our shared ecosystems.
         </p>
       </CalloutPanel>
@@ -84,7 +85,7 @@ const seo = buildSEO({
     <SectionDivider variant="default" spacing="normal" />
 
     <!-- ================================================================ -->
-    <!-- SECTION 2 — Values -->
+    <!-- SECTION: Core values driving practice -->
     <!-- ================================================================ -->
     <section class="page-section" aria-labelledby="values-title">
       <SectionHeader
@@ -93,25 +94,30 @@ const seo = buildSEO({
         align="center"
       />
 
+      <!-- GRID: Value cards outlining commitments -->
       <div class="card-grid">
+        <!-- CARD: Openness principle -->
         <Card as="article" variant="surface">
           <h3>Openness</h3>
           <p>
             All research, data, and methods are shared under open licenses — enabling anyone to learn, build, and improve.
           </p>
         </Card>
+        <!-- CARD: Safety principle -->
         <Card as="article" variant="surface">
           <h3>Safety</h3>
           <p>
             We prioritise safe practices in plasma and electrical work, ensuring care for both people and environment.
           </p>
         </Card>
+        <!-- CARD: Reciprocity principle -->
         <Card as="article" variant="surface">
           <h3>Reciprocity</h3>
           <p>
             Knowledge flows both ways — contributors give back through transparency, attribution, and open dialogue.
           </p>
         </Card>
+        <!-- CARD: Commons integrity principle -->
         <Card as="article" variant="surface">
           <h3>Commons Integrity</h3>
           <p>
@@ -128,10 +134,10 @@ const seo = buildSEO({
     <section class="etymology-callout" aria-labelledby="etymology-heading">
       <div class="etymology-content">
         <h2 id="etymology-heading" class="visually-hidden">Origin of arc^</h2>
-        
+
         <!-- Context intro -->
         <p class="etymology-context">The name <em>arc^</em> holds dual meaning:</p>
-        
+
         <!-- Pronunciation block -->
         <div class="pronunciation-block">
           <div class="pronunciation-title">
@@ -152,7 +158,7 @@ const seo = buildSEO({
             <strong>"to arc up"</strong> <em>(Australian slang)</em><br>
             to rise in defense of people and planet
           </p>
-          
+
           <p class="etymology-definition">
             <strong>"^"</strong> <em>(mathematical notation)</em><br>
             to the power of — amplifying change through the scientific method
@@ -161,7 +167,7 @@ const seo = buildSEO({
       </div>
     </section>
     <!-- ================================================================ -->
-    <!-- SECTION 3 — Meaning of the Name -->
+    <!-- SECTION: Reinforces symbolic interpretations of name -->
     <!-- ================================================================ -->
     <section class="page-section" aria-labelledby="name-title">
       <SectionHeader
@@ -170,23 +176,28 @@ const seo = buildSEO({
         align="center"
       />
 
+      <!-- GRID: Iconic meanings of arc^ -->
       <div class="card-grid">
+        <!-- CARD: Rising in defense meaning -->
         <Card as="article" variant="outline">
           <h3>↑ “To Arc Up”</h3>
           <p>To rise in defense of people and planet.</p>
         </Card>
+        <!-- CARD: Amplification meaning -->
         <Card as="article" variant="outline">
           <h3>^ “To the Power Of”</h3>
           <p>Amplification through shared knowledge and collaboration.</p>
         </Card>
+        <!-- CARD: Plasma arc meaning -->
         <Card as="article" variant="outline">
           <h3>⚡ “Plasma Arc”</h3>
           <p>The energetic bridge between matter and air — symbolising transformation.</p>
         </Card>
       </div>
 
+      <!-- EQUATION: Synthesizes symbolic expression -->
       <p class="reflection-text center">
-        arc^ = resistance × regeneration × plasma energy  
+        arc^ = resistance × regeneration × plasma energy
         <br />ArcUp is both metaphor and method — a spark that rises, connects, and transforms.
       </p>
       <!-- 💬 Claude: could use animated caret glyph or subtle electric glow underline here for motion. -->
@@ -195,7 +206,7 @@ const seo = buildSEO({
     <SectionDivider variant="default" spacing="normal" />
 
     <!-- ================================================================ -->
-    <!-- SECTION 4 — The ArcUp Phases -->
+    <!-- SECTION: Phase roadmap from experimentation to commons -->
     <!-- ================================================================ -->
     <section class="page-section" aria-labelledby="phases-title">
       <SectionHeader
@@ -204,35 +215,40 @@ const seo = buildSEO({
         align="center"
       />
 
+      <!-- GRID: Development phases cards -->
       <div class="card-grid">
+        <!-- CARD: Phase 1 outline -->
         <Card as="article" variant="surface">
           <h3>🌱 Phase 1 — Bench-Scale Experiments</h3>
           <p>
-            Simple dielectric barrier discharge (DBD) setups test plasma–water interactions for purification, agriculture, 
+            Simple dielectric barrier discharge (DBD) setups test plasma–water interactions for purification, agriculture,
             and ecological applications. All results are shared openly to build a transparent foundation of reproducible research.
           </p>
         </Card>
 
+        <!-- CARD: Phase 2 outline -->
         <Card as="article" variant="surface">
           <h3>🌍 Phase 2 — Community Prototyping</h3>
           <p>
-            Shared templates and build guides evolve from open data.  
+            Shared templates and build guides evolve from open data.
             This phase builds a commons of plasma tools where knowledge circulates responsibly and safely.
           </p>
         </Card>
 
+        <!-- CARD: Phase 3 outline -->
         <Card as="article" variant="surface">
           <h3>🔭 Phase 3 — Collaborative Application</h3>
           <p>
-            Interdisciplinary teams and institutions co-develop plasma systems in real-world contexts.  
+            Interdisciplinary teams and institutions co-develop plasma systems in real-world contexts.
             Governance shifts from ownership to custodianship — ensuring discoveries remain open for all.
           </p>
         </Card>
       </div>
 
+      <!-- CALLOUT: Clarifies success metric -->
       <CalloutPanel variant="neutral" icon="🧭" title="Our Direction">
         <p>
-          ArcUp’s progress isn’t measured by products but by participation — 
+          ArcUp’s progress isn’t measured by products but by participation —
           by how widely knowledge and responsibility are shared.
         </p>
       </CalloutPanel>
@@ -241,7 +257,7 @@ const seo = buildSEO({
     <SectionDivider variant="strong" spacing="spacious" />
 
     <!-- ================================================================ -->
-    <!-- SECTION 5 — The Broader Vision -->
+    <!-- SECTION: Broader vision statement -->
     <!-- ================================================================ -->
     <section class="reflection-section" aria-labelledby="vision-title">
       <SectionHeader
@@ -261,13 +277,15 @@ const seo = buildSEO({
       </p>
     </section>
 
+    <!-- CTA SECTION: Invitation to join mission -->
     <Card as="section" class="final-cta" variant="surface" padding="spacious">
       <SectionHeader title="Ready to Join?" align="center" headingLevel="h2" />
       <p>
-        Help build the open future of regenerative plasma technology.  
+        Help build the open future of regenerative plasma technology.
         Your curiosity and care are what keep ArcUp alive.
       </p>
 
+      <!-- CTA BUTTON: Interest form link -->
       <LinkButton
         href={EXTERNAL_LINKS.formURL}
         variant="primary"
@@ -278,7 +296,7 @@ const seo = buildSEO({
       </LinkButton>
 
       <p class="final-note">
-        Or explore <a href={withBase("/how")}>how we work</a> and the 
+        Or explore <a href={withBase("/how")}>how we work</a> and the
         <a href={withBase("/license")}>licenses</a> that keep our research open.
       </p>
     </Card>

--- a/src/pages/draft/origin.astro
+++ b/src/pages/draft/origin.astro
@@ -40,7 +40,7 @@ const seo = buildSEO({
 
   <main id="main-content" class="page-shell" aria-labelledby="page-title">
 
-    <!-- Breadcrumb -->
+    <!-- BREADCRUMB: Draft navigation for origin story -->
     <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href={withBase("/about")}>About</a>
       <span aria-hidden="true">/</span>
@@ -48,7 +48,7 @@ const seo = buildSEO({
     </nav>
 
     <!-- ================================================================ -->
-    <!-- HERO -->
+    <!-- HERO SECTION: Frames central question about open discovery -->
     <!-- ================================================================ -->
     <header class="origin-hero" aria-labelledby="page-title">
       <p class="eyebrow">How ArcUp Began</p>
@@ -62,7 +62,7 @@ const seo = buildSEO({
     <SectionDivider variant="default" spacing="compact" />
 
     <!-- ================================================================ -->
-    <!-- SECTION 1 — The First Spark -->
+    <!-- SECTION: Step-by-step recount of early experiments -->
     <!-- ================================================================ -->
     <section class="page-section" aria-labelledby="spark-title">
       <SectionHeader
@@ -71,25 +71,29 @@ const seo = buildSEO({
         align="center"
       />
 
+      <!-- GRID: Six-stage experimentation journey -->
       <div class="card-grid">
+        <!-- CARD: Research curiosity phase -->
         <Card as="article" class="start-card" variant="surface" hover={true}>
           <span class="process-number">1</span>
           <h3>Curiosity</h3>
           <p>
-            I began reading plasma research papers from around the world, 
+            I began reading plasma research papers from around the world,
             studying how others explored plasma–water interactions.
           </p>
         </Card>
 
+        <!-- CARD: Foundational learning phase -->
         <Card as="article" class="start-card" variant="surface" hover={true}>
           <span class="process-number">2</span>
           <h3>Learning the Basics</h3>
           <p>
-            The papers were dense, so I turned to videos and tutorials. 
+            The papers were dense, so I turned to videos and tutorials.
             Watching others build home reactors helped me understand the core physics and electronics.
           </p>
         </Card>
 
+        <!-- CARD: Building hardware phase -->
         <Card as="article" class="start-card" variant="surface" hover={true}>
           <span class="process-number">3</span>
           <h3>Building a Reactor</h3>
@@ -98,38 +102,42 @@ const seo = buildSEO({
           </p>
         </Card>
 
+        <!-- CARD: Experiment iteration phase -->
         <Card as="article" class="start-card" variant="surface" hover={true}>
           <span class="process-number">4</span>
           <h3>Experimenting</h3>
           <p>
-            I tested different electrodes and water types.  
+            I tested different electrodes and water types.
             Accidentally formed salt crystals, and discovered plasma-treated water improved seed germination.
           </p>
         </Card>
 
+        <!-- CARD: Insight about potential -->
         <Card as="article" class="start-card" variant="surface" hover={true}>
           <span class="process-number">5</span>
           <h3>Discovering Potential</h3>
           <p>
-            Plasma could alter biological processes.  
+            Plasma could alter biological processes.
             I wondered how to design better systems for efficiency and ecological impact.
           </p>
         </Card>
 
+        <!-- CARD: Motivation to share openly -->
         <Card as="article" class="start-card" variant="surface" hover={true}>
           <span class="process-number">6</span>
           <h3>Sharing the Process</h3>
           <p>
-            What if I shared my progress publicly?  
-            Would others join in, help improve it, or replicate it?  
+            What if I shared my progress publicly?
+            Would others join in, help improve it, or replicate it?
             That question became the seed of ArcUp.
           </p>
         </Card>
       </div>
 
+      <!-- CALLOUT: Encourages collective experimentation -->
       <CalloutPanel variant="info" icon="⚡" title="Collective Spark">
         <p>
-          Watching seeds respond to plasma was the beginning of ArcUp.  
+          Watching seeds respond to plasma was the beginning of ArcUp.
           If one person could do this alone, imagine what we could create together.
         </p>
         <LinkButton href={withBase("/about/mission")} variant="ghost" icon="arrow-right">
@@ -141,7 +149,7 @@ const seo = buildSEO({
     <SectionDivider variant="default" spacing="compact" />
 
     <!-- ================================================================ -->
-    <!-- SECTION 2 — The Pattern We Refuse -->
+    <!-- SECTION: Critique of extractive innovation patterns -->
     <!-- ================================================================ -->
     <section class="page-section" aria-labelledby="pattern-title">
     <SectionHeader
@@ -178,7 +186,7 @@ const seo = buildSEO({
         <SectionDivider variant="strong" spacing="normal" />
 
     <!-- ================================================================ -->
-    <!-- SECTION 3 — From Reflection to Framework -->
+    <!-- SECTION: Transition from personal reflection to shared framework -->
     <!-- ================================================================ -->
     <section class="page-section" aria-labelledby="framework-title">
       <SectionHeader
@@ -205,7 +213,7 @@ const seo = buildSEO({
     <SectionDivider variant="subtle" spacing="spacious" />
 
     <!-- ================================================================ -->
-    <!-- SECTION 4 — Reflection / Closing -->
+    <!-- SECTION: Closing invitation to collaborate -->
     <!-- ================================================================ -->
     <section class="reflection-section" aria-labelledby="reflection-title">
       <SectionHeader
@@ -214,16 +222,16 @@ const seo = buildSEO({
         align="center"
       />
       <p class="reflection-text">
-        ArcUp began as one person’s experiment.  
-        My hope is that it grows into a collective practice —  
+        ArcUp began as one person’s experiment.
+        My hope is that it grows into a collective practice —
         a shared opportunity to rethink what progress means and what kind of world we want to build.
       </p>
     </section>
 
-    <!-- Navigation -->
+    <!-- NAVIGATION: Draft links to related About pages -->
     <nav class="origin-nav" aria-label="Continue exploring">
-      <LinkButton 
-        href={withBase("/about/founder")} 
+      <LinkButton
+        href={withBase("/about/founder")}
         variant="primary"
         icon="arrow-right"
       >

--- a/src/pages/how.astro
+++ b/src/pages/how.astro
@@ -34,7 +34,7 @@ const seo = buildSEO({
 
   <main id="main-content" class="page-shell" aria-labelledby="how-title">
     
-    <!-- HERO SECTION -->
+    <!-- HERO SECTION: Introduces research philosophy and promises transparency -->
     <header class="how-hero" aria-labelledby="how-title">
       <p class="eyebrow">Our Research Framework</p>
       <h1 id="how-title">How arc^ Works</h1>
@@ -44,7 +44,7 @@ const seo = buildSEO({
       </div>
     </header>
 
-    <!-- PHILOSOPHY -->
+    <!-- CALLOUT SECTION: Philosophy and foundational principles overview -->
     <section class="how-callout">
       <Card>
         <div class="method-content">
@@ -53,6 +53,7 @@ const seo = buildSEO({
             align="left"
             headingLevel="h2"
           />
+          <!-- TEXT BLOCK: Summary of guiding framework -->
           <p>arc^ is guided by <strong>re:earth</strong> — a regenerative technology framework that asks "what world does this create?" before building anything.</p>
           <p>Re:earth includes the RE:TECH design approach and the ethical commitments that shape how we work. This philosophical foundation will soon live on its own site.</p>
           <p class="callout-note">For now, understand that arc^ research is grounded in: openness, ecological interdependence, future-consciousness, harm prevention, and planetary restoration.</p>
@@ -60,7 +61,7 @@ const seo = buildSEO({
       </Card>
     </section>
 
-    <!-- RESEARCH METHOD -->
+    <!-- SECTION: Seven-step research methodology -->
     <section>
       <SectionHeader
         title="Our Research Method"
@@ -69,8 +70,10 @@ const seo = buildSEO({
         headingLevel="h2"
       />
 
+      <!-- GRID: Sequential method step cards -->
       <div class="method-steps">
-        
+
+        <!-- CARD: Commitment to openness from start -->
         <Card as="article" class="method-step">
           <div class="method-step-header">
             <span class="method-num">1</span>
@@ -79,6 +82,7 @@ const seo = buildSEO({
           <p>Document from day zero. Every hypothesis, design choice, and experiment goes public from the beginning. No "big reveal" launches — just incremental, transparent progress.</p>
         </Card>
 
+        <!-- CARD: Prioritize safety considerations -->
         <Card as="article" class="method-step">
           <div class="method-step-header">
             <span class="method-num">2</span>
@@ -87,6 +91,7 @@ const seo = buildSEO({
           <p>Every project starts with risk assessment. We identify potential harms — ecological, social, physical — and design safeguards before we build. If we can't do it safely, we don't do it.</p>
         </Card>
 
+        <!-- CARD: Sharing outputs openly -->
         <Card as="article" class="method-step">
           <div class="method-step-header">
             <span class="method-num">3</span>
@@ -95,6 +100,7 @@ const seo = buildSEO({
           <p>All designs, data, and documentation are released under open licenses. No paywalls. No patents. No proprietary lockdowns. Knowledge belongs in the commons.</p>
         </Card>
 
+        <!-- CARD: Transparently document failures -->
         <Card as="article" class="method-step">
           <div class="method-step-header">
             <span class="method-num">4</span>
@@ -103,6 +109,7 @@ const seo = buildSEO({
           <p>Failed experiments get the same treatment as successful ones. We publish what didn't work, why it didn't work, and what we learned. Honesty over optics.</p>
         </Card>
 
+        <!-- CARD: Emphasize collaboration -->
         <Card as="article" class="method-step">
           <div class="method-step-header">
             <span class="method-num">5</span>
@@ -111,6 +118,7 @@ const seo = buildSEO({
           <p>Research isn't a solo act. We invite feedback, contributions, and critiques from anyone willing to engage thoughtfully. The best ideas come from many minds, not just one.</p>
         </Card>
 
+        <!-- CARD: Focus on replicability -->
         <Card as="article" class="method-step">
           <div class="method-step-header">
             <span class="method-num">6</span>
@@ -119,6 +127,7 @@ const seo = buildSEO({
           <p>Every protocol is written to be reproducible by others. We use accessible tools, clear documentation, and open standards so anyone can verify and build on our work.</p>
         </Card>
 
+        <!-- CARD: Center ecological benefit -->
         <Card as="article" class="method-step">
           <div class="method-step-header">
             <span class="method-num">7</span>
@@ -130,7 +139,7 @@ const seo = buildSEO({
       </div>
     </section>
 
-    <!-- LEARN MORE SECTION -->
+    <!-- CALLOUT SECTION: Links to detailed safety and licensing resources -->
     <section class="how-callout">
       <Card variant="outline">
         <div class="method-content">
@@ -139,6 +148,7 @@ const seo = buildSEO({
             align="center"
             headingLevel="h2"
           />
+          <!-- CTA GROUP: Navigation to subpages -->
           <p>Want to understand our safety protocols or licensing approach in detail? Check out the dedicated pages below.</p>
           <div class="how-actions">
             <LinkButton href={withBase("/how/safety")} variant="primary">

--- a/src/pages/how/licensing.astro
+++ b/src/pages/how/licensing.astro
@@ -35,7 +35,7 @@ const seo = buildSEO({
 
   <main id="main-content" class="page-shell" aria-labelledby="licensing-title">
     
-    <!-- HERO SECTION -->
+    <!-- HERO SECTION: Establishes commitment to open licensing -->
     <header class="how-hero" aria-labelledby="licensing-title">
       <p class="eyebrow">Knowledge in the Commons</p>
       <h1 id="licensing-title">Open Licensing</h1>
@@ -44,7 +44,7 @@ const seo = buildSEO({
       </div>
     </header>
 
-    <!-- WHY OPEN -->
+    <!-- CALLOUT SECTION: Rationale for open licensing stance -->
     <section class="how-callout">
       <Card>
         <div class="licensing-content">
@@ -53,6 +53,7 @@ const seo = buildSEO({
             align="left"
             headingLevel="h2"
           />
+          <!-- TEXT BLOCK: Explains anti-extractive philosophy -->
           <p>Proprietary technology is extractive. It locks knowledge behind paywalls, limits who can contribute, and serves profit over collective good.</p>
           <p>We use <strong>copyleft licenses</strong> to ensure that arc^ research remains open, accessible, and non-extractive. Anyone can use, modify, and build on our work — as long as derivatives stay open too.</p>
           <p>This isn't just ideology. It's a practical commitment to <em>keeping knowledge in the commons</em> where it can serve the most people.</p>
@@ -60,7 +61,7 @@ const seo = buildSEO({
       </Card>
     </section>
 
-    <!-- LICENSE GRID -->
+    <!-- SECTION: Breakdown of license types used by ArcUp -->
     <section>
       <SectionHeader
         title="Our Licenses"
@@ -69,8 +70,10 @@ const seo = buildSEO({
         headingLevel="h2"
       />
 
+      <!-- GRID: License cards for hardware, documentation, and software -->
       <div class="license-grid">
-        
+
+        <!-- CARD: Hardware licensing details -->
         <Card as="article" class="license-card">
           <div class="license-header">
             <h3>CERN-OHL-S v2</h3>
@@ -90,6 +93,7 @@ const seo = buildSEO({
           </a>
         </Card>
 
+        <!-- CARD: Documentation licensing details -->
         <Card as="article" class="license-card">
           <div class="license-header">
             <h3>CC BY-NC-SA 4.0</h3>
@@ -109,6 +113,7 @@ const seo = buildSEO({
           </a>
         </Card>
 
+        <!-- CARD: Software licensing details -->
         <Card as="article" class="license-card">
           <div class="license-header">
             <h3>AGPL-3.0</h3>
@@ -131,7 +136,7 @@ const seo = buildSEO({
       </div>
     </section>
 
-    <!-- COMMERCIAL USE -->
+    <!-- CALLOUT SECTION: Guidance on commercial applications -->
     <section class="how-callout">
       <Card variant="outline">
         <div class="licensing-content">
@@ -140,6 +145,7 @@ const seo = buildSEO({
             align="left"
             headingLevel="h2"
           />
+          <!-- TEXT BLOCK: Clarifies conditions for market activity -->
           <p>Our documentation is non-commercial, but hardware and software licenses allow commercial use — <em>as long as derivatives stay open</em>.</p>
           <p>This means you can build and sell products based on arc^ designs, but you must share your modifications and improvements under the same open licenses.</p>
           <p><strong>Why?</strong> We're not anti-market. We're anti-extraction. If someone builds a business using arc^ work, the knowledge they generate should flow back to the commons, not disappear behind patents.</p>
@@ -147,7 +153,7 @@ const seo = buildSEO({
       </Card>
     </section>
 
-    <!-- PRINCIPLE -->
+    <!-- CALLOUT SECTION: Core principle reminder -->
     <section class="how-callout">
       <Card>
         <div class="licensing-content">
@@ -156,13 +162,14 @@ const seo = buildSEO({
             align="center"
             headingLevel="h2"
           />
+          <!-- TEXT BLOCK: Reinforces commons-first ethos -->
           <p style="text-align: center;">Knowledge is not property. It's a commons that grows when shared.</p>
           <p style="text-align: center;">Our licensing ensures that arc^ research serves <em>collective futures</em>, not private shareholders.</p>
         </div>
       </Card>
     </section>
 
-    <!-- NAVIGATION -->
+    <!-- SECTION: Navigation buttons to related pages -->
     <section class="how-callout">
       <div class="how-actions">
         <LinkButton href={withBase("/how/safety")} variant="outline">

--- a/src/pages/how/safety.astro
+++ b/src/pages/how/safety.astro
@@ -35,7 +35,7 @@ const seo = buildSEO({
 
   <main id="main-content" class="page-shell" aria-labelledby="safety-title">
     
-    <!-- HERO SECTION -->
+    <!-- HERO SECTION: Positions safety commitments for plasma research -->
     <header class="how-hero" aria-labelledby="safety-title">
       <p class="eyebrow">Our Commitment</p>
       <h1 id="safety-title">Safety Protocols</h1>
@@ -44,7 +44,7 @@ const seo = buildSEO({
       </div>
     </header>
 
-    <!-- SAFETY GRID -->
+    <!-- SECTION: Detailed safety domains and protocols -->
     <section class="safety-section">
       <SectionHeader
         title="Safety is <em>Non-Negotiable</em>"
@@ -53,37 +53,44 @@ const seo = buildSEO({
         headingLevel="h2"
       />
 
+      <!-- GRID: Six safety focus areas -->
       <div class="safety-grid">
+        <!-- CARD: Electrical safety standards -->
         <Card as="article" class="safety-card">
           <div class="safety-icon">⚡</div>
           <h3>High-Voltage Protocols</h3>
           <p>All electrical work follows safety standards. Devices include kill switches, grounding, and isolation. No improvisation with power systems.</p>
         </Card>
 
+        <!-- CARD: Chemical monitoring practices -->
         <Card as="article" class="safety-card">
           <div class="safety-icon">🧪</div>
           <h3>Chemical Safety</h3>
           <p>Plasma generates reactive oxygen and nitrogen species. We test water chemistry before and after treatment. No application without baseline data.</p>
         </Card>
 
+        <!-- CARD: Ecological safeguard measures -->
         <Card as="article" class="safety-card">
           <div class="safety-icon">🌿</div>
           <h3>Ecological Safety</h3>
           <p>Field trials start small and controlled. We monitor for unintended impacts on soil, water, and organisms. If harm appears, we pause.</p>
         </Card>
 
+        <!-- CARD: Community consent requirements -->
         <Card as="article" class="safety-card">
           <div class="safety-icon">👥</div>
           <h3>Community Safety</h3>
           <p>No experimentation on land without informed consent from those who live there. Community veto power is real and respected.</p>
         </Card>
 
+        <!-- CARD: Dual-use risk mitigation -->
         <Card as="article" class="safety-card">
           <div class="safety-icon">🛑</div>
           <h3>Dual-Use Prevention</h3>
           <p>If research trends toward weaponization, surveillance, or exploitation — we stop. No exceptions, even if technically interesting.</p>
         </Card>
 
+        <!-- CARD: Transparent documentation culture -->
         <Card as="article" class="safety-card">
           <div class="safety-icon">📋</div>
           <h3>Documentation</h3>
@@ -91,13 +98,14 @@ const seo = buildSEO({
         </Card>
       </div>
 
+      <!-- CALLOUT: Reiterate core decision principle -->
       <Card class="safety-principle">
         <h3>Core Principle</h3>
         <p>When in doubt, we consult experts. When risk is unclear, we pause. When harm is likely, we stop. Research can wait — safety cannot.</p>
       </Card>
     </section>
 
-    <!-- RELATED PAGES -->
+    <!-- SECTION: Navigation to related methodology resources -->
     <section class="getting-started-section">
       <SectionHeader
         title="Related"
@@ -106,7 +114,9 @@ const seo = buildSEO({
         headingLevel="h2"
       />
 
+      <!-- GRID: Related resource cards -->
       <div class="getting-started-cards">
+        <!-- CARD: Link to overall methods page -->
         <Card as="article" class="start-card">
           <h3>How We Work</h3>
           <p>Understand our 7-step research method and RE:TECH principles.</p>
@@ -115,6 +125,7 @@ const seo = buildSEO({
           </LinkButton>
         </Card>
 
+        <!-- CARD: Link to licensing practices -->
         <Card as="article" class="start-card">
           <h3>Open Licensing</h3>
           <p>All outputs stay in the commons through copyleft licenses.</p>
@@ -123,6 +134,7 @@ const seo = buildSEO({
           </LinkButton>
         </Card>
 
+        <!-- CARD: Link to participation details -->
         <Card as="article" class="start-card">
           <h3>Join the Work</h3>
           <p>Ready to contribute? Learn how to get involved.</p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,6 +29,7 @@ const seo = buildSEO({
   seo={seo}
   navActive="home"
 >
+  <!-- LAYOUT SLOT: interactive arc canvas background prior to header -->
   <ArcCanvas slot="before-header" />
 
   <main id="main-content" class="page-shell" aria-labelledby="main-title">
@@ -37,61 +38,73 @@ const seo = buildSEO({
          HERO SECTION — Core Message
          ======================================================================== -->
       <header class="home-hero" aria-labelledby="main-title" aria-describedby="home-summary">
+        <!-- HERO EYEBROW: concise mission cue -->
         <p class="eyebrow">Open Research for a Thriving Earth</p>
 
+        <!-- HERO TITLE: primary brand mark -->
         <h1 id="main-title" class="hero-title">arc^</h1>
 
+        <!-- HERO LEDE: high-level summary of ArcUp focus -->
         <p class="lead home-lede">
-          <em>ArcUp</em> is an open experimental research framework developing 
+          <em>ArcUp</em> is an open experimental research framework developing
           <strong>plasma-based systems for ecological regeneration and resilience.</strong>
         </p>
 
+        <!-- HERO CONTEXT: supporting mission statement -->
         <p class="home-body">
-          We explore how controlled electrical discharges can purify water systems, 
-          restore soil function, and repair damaged ecosystems — 
+          We explore how controlled electrical discharges can purify water systems,
+          restore soil function, and repair damaged ecosystems —
           guided by the belief that technology should <em>serve life, not profit.</em>
         </p>
 
+        <!-- HERO ETHICS CALLOUT: links to guiding framework -->
         <p class="home-context">
-          Our work follows the 
+          Our work follows the
           <a href="https://repractice.xbyali.page" class="underline" target="_blank" rel="noopener noreferrer">
             Repractice Ethical Framework
-          </a>, 
+          </a>,
           ensuring all research remains <em>open, regenerative, and accountable to the commons.</em>
         </p>
 
-      <div class="hero-actions">
-        <LinkButton href={withBase("/projects")} variant="primary" icon="arrow-right">
-          Start with a Project Idea
-        </LinkButton>
-        <LinkButton href={withBase("/how")} variant="outline" icon="arrow-right">
-           Learn Our Approach
-        </LinkButton>
-      </div>
-    </header>
+        <!-- HERO ACTIONS: primary navigation CTAs -->
+        <div class="hero-actions">
+          <!-- CTA BUTTON: direct path to projects overview -->
+          <LinkButton href={withBase("/projects")} variant="primary" icon="arrow-right">
+            Start with a Project Idea
+          </LinkButton>
+          <!-- CTA BUTTON: path to methodology page -->
+          <LinkButton href={withBase("/how")} variant="outline" icon="arrow-right">
+             Learn Our Approach
+          </LinkButton>
+        </div>
+      </header>
 
     <!-- ========================================================================
          SITE NAVIGATION — Key Pages
          ======================================================================== -->
     <nav class="home-nav-cards" aria-label="Main site sections">
+      <!-- NAV CARD: overview of ArcUp background -->
       <a href={withBase("/about")} class="nav-card">
         <h3>About</h3>
         <p>Learn where ArcUp began and how it aligns with Repractice ethics</p>
         <span class="nav-card-arrow" aria-hidden="true">→</span>
       </a>
 
+      <!-- NAV CARD: list of active research initiatives -->
       <a href={withBase("/projects")} class="nav-card">
         <h3>Projects</h3>
         <p>Explore open plasma research and ecological applications</p>
         <span class="nav-card-arrow" aria-hidden="true">→</span>
       </a>
 
+      <!-- NAV CARD: process and methodology resources -->
       <a href={withBase("/how")} class="nav-card">
         <h3>How We Work</h3>
         <p>Discover our methods, ethics, and approach to open experimentation</p>
         <span class="nav-card-arrow" aria-hidden="true">→</span>
       </a>
 
+      <!-- NAV CARD: invitation for collaborators -->
       <a href={withBase("/join")} class="nav-card">
         <h3>Join</h3>
         <p>Collaborate with us—engineers, scientists, and storytellers welcome</p>
@@ -101,11 +114,13 @@ const seo = buildSEO({
 
   </main>
 
+  <!-- PAGE NAVIGATION: persistent footer nav between primary sections -->
   <PageNavigation currentPage="home" />
 
   <!-- ========================================================================
        AUDIO PRONUNCIATION SCRIPT
        ======================================================================== -->
+  <!-- SCRIPT: provides fallback pronunciation playback for "arc up" -->
   <script>
     const btn = document.querySelector('.audio-button');
     if (btn) {

--- a/src/pages/join.astro
+++ b/src/pages/join.astro
@@ -39,7 +39,7 @@ const seo = buildSEO({
 
   <main id="main-content" class="page-shell" aria-labelledby="join-title">
     
-    <!-- HERO - No changes -->
+    <!-- HERO SECTION: Invitation for contributors to join ArcUp framework -->
     <header class="join-hero" aria-labelledby="join-title">
       <p class="eyebrow">Building Technology for a Better Future</p>
       <h1 id="join-title">Join arc^</h1>
@@ -52,10 +52,10 @@ const seo = buildSEO({
       </p>
     </header>
 
-    <!-- ACKNOWLEDGEMENTS SECTION 
-         MINIMAL CHANGE: Only replace surface-panel with Card 
-         Keep ALL original HTML structure and classes -->
+    <!-- SECTION: Acknowledgements of open science movements supporting ArcUp -->
+    <!-- NOTE: Layout preserved from prior migration guidance -->
     <Card as="section" class="acknowledgements-section" aria-labelledby="acknowledgements-heading">
+      <!-- INTRO TEXT: Sets context for inspiration list -->
       <div class="acknowledgements-intro-text">
         <p>Before you think this is just hypothetical — <strong>we are not alone.</strong> Others have already spearheaded this movement.</p>
       </div>
@@ -67,46 +67,56 @@ const seo = buildSEO({
         headingLevel="h2"
       />
 
+      <!-- SUBHEAD: Describes list of peer inspirations -->
       <div class="acknowledgements-intro">
         <p><strong>We draw inspiration and learn from:</strong></p>
       </div>
 
+      <!-- GRID: Showcase of organizations and communities influencing ArcUp -->
       <div class="acknowledgements-grid">
+        <!-- CARD: Open Hardware Science collective -->
         <article class="acknowledgement-card">
           <h3><a href="https://openhardware.science/" target="_blank" rel="noopener">Open Hardware Science</a></h3>
           <p>Demonstrating that scientific tools can be accessible, repairable, and shared freely across borders and institutions.</p>
         </article>
 
+        <!-- CARD: GOSH Community network -->
         <article class="acknowledgement-card">
           <h3><a href="https://www.gosh-community.org/" target="_blank" rel="noopener">GOSH Community</a></h3>
           <p>Building a global network where hardware knowledge flows freely, centering equity and local agency in tool development.</p>
         </article>
 
+        <!-- CARD: Public Lab community science pioneers -->
         <article class="acknowledgement-card">
           <h3><a href="https://publiclab.org/" target="_blank" rel="noopener">Public Lab</a></h3>
           <p>Pioneering community science with accessible tools for environmental monitoring and data sovereignty.</p>
         </article>
 
+        <!-- CARD: Appropedia collaborative knowledge base -->
         <article class="acknowledgement-card">
           <h3><a href="https://www.appropedia.org/" target="_blank" rel="noopener">Appropedia</a></h3>
           <p>Creating a living library of sustainable technology and collaborative problem-solving for communities worldwide.</p>
         </article>
 
+        <!-- CARD: Open Source Hardware Association advocates -->
         <article class="acknowledgement-card">
           <h3><a href="https://www.oshwa.org/" target="_blank" rel="noopener">OSHWA</a></h3>
           <p>Advocating for open source hardware principles and building infrastructure for collaborative innovation.</p>
         </article>
 
+        <!-- CARD: Farm Hack agricultural tool community -->
         <article class="acknowledgement-card">
           <h3><a href="https://farmhack.org/" target="_blank" rel="noopener">Farm Hack</a></h3>
           <p>Empowering farmers as designers and innovators, sharing agricultural tools and knowledge in the commons.</p>
         </article>
 
+        <!-- CARD: Community Science alliances around the world -->
         <article class="acknowledgement-card">
           <h3><a href="https://www.scienceforsociety.org/" target="_blank" rel="noopener">Community Science</a></h3>
           <p>Movements globally that center local knowledge, consent-based research, and accountability to communities.</p>
         </article>
 
+        <!-- CARD: Creative Commons stewardship of open licensing -->
         <article class="acknowledgement-card">
           <h3><a href="https://creativecommons.org/science/" target="_blank" rel="noopener">Creative Commons</a></h3>
           <p>Building legal infrastructure that lets knowledge flow freely while protecting creator rights and community interests.</p>
@@ -118,8 +128,7 @@ const seo = buildSEO({
       </p>
     </Card>
 
-    <!-- GETTING STARTED SECTION
-         Keep ALL original structure - only change surface-panel wrapper -->
+    <!-- SECTION: Getting started pathways for new contributors -->
     <section class="getting-started-section">
       <SectionHeader
         title="How to Get Started"
@@ -128,19 +137,23 @@ const seo = buildSEO({
         headingLevel="h2"
       />
 
+      <!-- GRID: Three-step process cards -->
       <div class="getting-started-grid">
+        <!-- CARD: Onboarding guidance for students and researchers -->
         <Card as="article" class="start-card">
           <span class="process-number">1</span>
           <h3>Students & Researchers</h3>
           <p>If you're working on a thesis, final-year project, or independent research, you can integrate arc^ projects into your academic work. You'll need supervisor approval and a commitment to open licensing.</p>
         </Card>
 
+        <!-- CARD: Entry path for independent contributors -->
         <Card as="article" class="start-card">
           <span class="process-number">2</span>
           <h3>Independent Contributors</h3>
           <p>Makers, engineers, and technical contributors can jump into hardware design, code, or data analysis. Start by exploring existing projects and proposing contributions.</p>
         </Card>
 
+        <!-- CARD: Engagement channel for community partners -->
         <Card as="article" class="start-card">
           <span class="process-number">3</span>
           <h3>Community Partners</h3>
@@ -149,8 +162,7 @@ const seo = buildSEO({
       </div>
     </section>
 
-    <!-- WAYS TO CONTRIBUTE SECTION
-         Keep ALL original structure -->
+    <!-- SECTION: Menu of contribution areas and responsibilities -->
     <section class="contribute-section">
       <SectionHeader
         title="Ways to Contribute"
@@ -159,8 +171,9 @@ const seo = buildSEO({
         headingLevel="h2"
       />
 
+      <!-- GRID: Contribution area cards with icons -->
       <div class="contribute-grid">
-        <!-- Card 1: Hardware Development -->
+        <!-- CARD: Hardware development focus -->
         <Card as="article" class="contribute-card">
           <div class="card-icon">⚡</div>
           <h3>Hardware Development</h3>
@@ -175,7 +188,7 @@ const seo = buildSEO({
           <p class="ideal-for"><strong>Ideal for:</strong> Electrical engineers, makers, hardware hackers</p>
         </Card>
 
-        <!-- Card 2: Software & Data -->
+        <!-- CARD: Software and data contribution focus -->
         <Card as="article" class="contribute-card">
           <div class="card-icon">💻</div>
           <h3>Software & Data</h3>
@@ -190,7 +203,7 @@ const seo = buildSEO({
           <p class="ideal-for"><strong>Ideal for:</strong> Developers, data scientists, UX designers</p>
         </Card>
 
-        <!-- Card 3: Documentation & Media -->
+        <!-- CARD: Documentation and media storytelling -->
         <Card as="article" class="contribute-card">
           <div class="card-icon">📝</div>
           <h3>Documentation & Media</h3>
@@ -205,7 +218,7 @@ const seo = buildSEO({
           <p class="ideal-for"><strong>Ideal for:</strong> Writers, designers, videographers, educators</p>
         </Card>
 
-        <!-- Card 4: Field Testing -->
+        <!-- CARD: Field testing partnership focus -->
         <Card as="article" class="contribute-card">
           <div class="card-icon">🌱</div>
           <h3>Field Testing</h3>
@@ -220,7 +233,7 @@ const seo = buildSEO({
           <p class="ideal-for"><strong>Ideal for:</strong> Farmers, gardeners, land stewards</p>
         </Card>
 
-        <!-- Card 5: Research Support -->
+        <!-- CARD: Research support and validation -->
         <Card as="article" class="contribute-card">
           <div class="card-icon">🔬</div>
           <h3>Research Support</h3>
@@ -235,7 +248,7 @@ const seo = buildSEO({
           <p class="ideal-for"><strong>Ideal for:</strong> Independent researchers, students (any discipline), data analysts</p>
         </Card>
 
-        <!-- Card 6: Community Partnerships -->
+        <!-- CARD: Community partnership collaboration -->
         <Card as="article" class="contribute-card">
           <div class="card-icon">🌍</div>
           <h3>Community Partnerships</h3>
@@ -252,8 +265,7 @@ const seo = buildSEO({
       </div>
     </section>
 
-    <!-- EXPECTATIONS SECTION
-         Keep ALL original structure -->
+    <!-- SECTION: Expectations and working agreements -->
     <section class="expectations-section">
       <SectionHeader
         title="What to Expect"
@@ -262,32 +274,39 @@ const seo = buildSEO({
         headingLevel="h2"
       />
 
+      <!-- GRID: Six principles guiding participation -->
       <div class="expectations-grid">
+        <!-- CARD: Safety protocols reminder -->
         <Card as="article" class="expectation-card">
           <h3>Safety First</h3>
           <p>High-voltage plasma requires proper protocols. Safety concerns are non-negotiable. If you're unsure about a procedure, ask before proceeding.</p>
         </Card>
 
+        <!-- CARD: Open documentation requirement -->
         <Card as="article" class="expectation-card">
           <h3>Open by Default</h3>
           <p>All work is documented and shared openly. Experiments are logged from day one, not just when results are favorable. Data, methods, and designs remain in the commons.</p>
         </Card>
 
+        <!-- CARD: Emphasis on learning through failure -->
         <Card as="article" class="expectation-card">
           <h3>Learn Through Failure</h3>
           <p>Mistakes are expected and documented. Early-stage work is messy — that's normal. Replication across contexts is how we build confidence in results.</p>
         </Card>
 
+        <!-- CARD: Attribution standards -->
         <Card as="article" class="expectation-card">
           <h3>Credit & Attribution</h3>
           <p>All contributors are named and credited. Your contributions matter and will be acknowledged publicly in outputs and documentation.</p>
         </Card>
 
+        <!-- CARD: Consent-centered collaboration -->
         <Card as="article" class="expectation-card">
           <h3>Consent-Based</h3>
           <p>Communities are partners, not subjects. All engagement is informed, voluntary, and shaped by local knowledge and priorities.</p>
         </Card>
 
+        <!-- CARD: Anti-extractive principle -->
         <Card as="article" class="expectation-card">
           <h3>No Extraction</h3>
           <p>arc^ refuses extractive models. If you're here to extract value without giving back, this isn't the place. Collaboration is reciprocal.</p>
@@ -295,8 +314,7 @@ const seo = buildSEO({
       </div>
     </section>
 
-    <!-- FINAL CTA
-         Only replace button with LinkButton -->
+    <!-- CTA SECTION: Final invitation to submit interest form -->
     <Card as="section" class="final-cta">
       <SectionHeader
         title="Ready to Join?"

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -61,7 +61,7 @@ const seo = buildSEO({
 
   <main id="main-content" class="page-shell" aria-labelledby="projects-title">
     
-    <!-- HERO SECTION -->
+    <!-- HERO SECTION: Overview of ArcUp project portfolio and participation invite -->
     <header class="projects-hero" aria-labelledby="projects-title">
       <p class="eyebrow">Early-Stage Collaborative Research</p>
       <h1 id="projects-title">Projects</h1>
@@ -72,14 +72,16 @@ const seo = buildSEO({
       </p>
     </header>
 
-    <!-- GETTING INVOLVED SECTION -->
+    <!-- SECTION: Audience-specific guidance on how to engage -->
     <section class="getting-involved-section" aria-labelledby="getting-involved-title">
-      <SectionHeader 
-        title="Getting Involved" 
+      <SectionHeader
+        title="Getting Involved"
         subtitle="arc^ is in early stages, which means you can help shape the direction from the ground up."
       />
-      
+
+      <!-- GRID: Three involvement pathways -->
       <div class="involvement-grid">
+        <!-- CARD: Student participation details -->
         <Card as="article" class="involvement-card">
           <div class="card-icon">🎓</div>
           <h3>For Students</h3>
@@ -87,6 +89,7 @@ const seo = buildSEO({
           <p class="card-note">We're here to support you — whether that's access to equipment, guidance on safety protocols, or help framing research questions.</p>
         </Card>
 
+        <!-- CARD: Researcher collaboration details -->
         <Card as="article" class="involvement-card">
           <div class="card-icon">🔬</div>
           <h3>For Researchers</h3>
@@ -94,6 +97,7 @@ const seo = buildSEO({
           <p class="card-note">This isn't about gatekeeping — it's about learning together and building on each other's insights.</p>
         </Card>
 
+        <!-- CARD: General community invitation -->
         <Card as="article" class="involvement-card">
           <div class="card-icon">🛠️</div>
           <h3>For Everyone</h3>
@@ -102,6 +106,7 @@ const seo = buildSEO({
         </Card>
       </div>
 
+      <!-- CTA: Link to external involvement form -->
       <div class="involvement-cta">
         <LinkButton href={EXTERNAL_LINKS.formURL} variant="primary" icon="external">
           Get Involved
@@ -109,21 +114,24 @@ const seo = buildSEO({
       </div>
     </section>
 
-    <!-- ALL PROJECTS SECTION (with categories) -->
+    <!-- SECTION: Dynamic project listing grouped by category -->
     <section class="all-projects-section" aria-labelledby="all-projects-title">
-      <SectionHeader 
+      <SectionHeader
         title="All Projects"
         subtitle="Each project follows RE:TECH principles — open, safe, iterative — and follows arc^'s licensing and governance."
       />
-      
+
+      <!-- LOOP: Iterate over project categories generated above -->
       {categories.map((category) => (
         <div class="project-category">
           {category !== 'Other' && (
             <h3 class="category-heading">{category}</h3>
           )}
-          
+
+          <!-- GRID: Project cards within {category} -->
           <div class="projects-grid">
             {projectsByCategory[category].map((project) => (
+              <!-- CARD: Individual project summary with status badge -->
               <Card as="article" class="project-card">
                 <div class="card-header">
                   <h4>
@@ -133,6 +141,7 @@ const seo = buildSEO({
                 </div>
                 <p class="card-summary">{project.data.summary}</p>
                 <p class="card-updated">Last updated: {project.data.lastUpdated}</p>
+                <!-- CTA: Button linking to full project page -->
                 <div class="card-actions">
                   <LinkButton href={withBase(`/projects/${project.slug}`)} variant="outline" icon="arrow-right">
                     Learn More
@@ -145,23 +154,25 @@ const seo = buildSEO({
       ))}
     </section>
 
-    <!-- BUILD YOUR OWN SECTION -->
+    <!-- SECTION: Encouragement to start new projects within framework -->
     <section class="build-your-own-section" aria-labelledby="build-your-own-title">
-      <SectionHeader 
-        title="Build Your Own" 
+      <SectionHeader
+        title="Build Your Own"
         subtitle="Don't see what you're looking for? You don't need our permission."
       />
-      
+
+      <!-- CALLOUT CARD: Highlights self-directed project pathway -->
       <Card class="build-your-own-content">
         <p>
-          arc^ isn't about gatekeeping — it's about <em>enabling</em>. If you understand 
-          <a href={withBase("/how")}>our philosophy</a> and commit to our <a href={withBase("/how/safety")}>safety protocols</a> 
+          arc^ isn't about gatekeeping — it's about <em>enabling</em>. If you understand
+          <a href={withBase("/how")}>our philosophy</a> and commit to our <a href={withBase("/how/safety")}>safety protocols</a>
           and <a href={withBase("/how/licensing")}>open licensing</a>, you can start your own arc^ project.
         </p>
         <p>
-          <strong>You have the power.</strong> Document your work. Share openly. Build for 
+          <strong>You have the power.</strong> Document your work. Share openly. Build for
           <em>life over profit</em>. That's all we ask.
         </p>
+        <!-- CTA: Link to philosophy overview -->
         <div class="button-wrapper">
           <LinkButton href={withBase("/how")} variant="outline" icon="arrow-right">
             Learn the Philosophy
@@ -170,7 +181,7 @@ const seo = buildSEO({
       </Card>
     </section>
 
-    <!-- LEGAL REMINDER -->
+    <!-- SECTION: Legal reminder about open licensing commitments -->
     <section class="legal-section">
       <h3>Open by Default</h3>
       <p>All arc^ projects follow our <a href={withBase("/how/licensing")}>non-extractive licensing model</a>. Research outputs, data, and designs stay in the commons.</p>

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -58,14 +58,14 @@ const hasLinks = project.data.links && project.data.links.length > 0;
 
   <main id="main-content" class="page-shell project-detail-shell">
     
-    <!-- BREADCRUMB -->
+    <!-- BREADCRUMB: Contextual navigation back to projects list -->
     <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href={withBase("/projects")}>Projects</a>
       <span aria-hidden="true">/</span>
       <span aria-current="page">{project.data.title}</span>
     </nav>
 
-    <!-- PROJECT HERO -->
+    <!-- HERO SECTION: Project title, status, and summary -->
     <header class="project-hero">
       <div class="project-meta">
         <StatusBadge status={project.data.status} />
@@ -103,17 +103,17 @@ const hasLinks = project.data.links && project.data.links.length > 0;
     </Card>
     -->
 
-    <!-- MAIN CONTENT -->
+    <!-- MAIN CONTENT: Markdown body and supporting sections -->
     <article class="project-content">
-      
-      <!-- Project Description (from markdown) -->
+
+      <!-- SECTION: Project description rendered from markdown -->
       <section class="content-section">
         <Content />
       </section>
 
-      <!-- Research Questions -->
+      <!-- SECTION: Research questions checklist -->
       <section class="content-section">
-        <SectionHeader 
+        <SectionHeader
           title="Research Questions"
           align="left"
           headingLevel="h2"
@@ -125,14 +125,16 @@ const hasLinks = project.data.links && project.data.links.length > 0;
         </ul>
       </section>
 
-      <!-- What We're Looking For -->
+      <!-- SECTION: Participation needs across expertise, resources, and support -->
       <section class="content-section">
-        <SectionHeader 
+        <SectionHeader
           title="What We're Looking For"
           align="left"
           headingLevel="h2"
         />
+        <!-- GRID: Three columns for different contribution types -->
         <div class="needs-grid">
+          <!-- COLUMN: Expertise needs -->
           <div class="need-item">
             <h3>Expertise</h3>
             <ul>
@@ -141,6 +143,7 @@ const hasLinks = project.data.links && project.data.links.length > 0;
               ))}
             </ul>
           </div>
+          <!-- COLUMN: Material resource needs -->
           <div class="need-item">
             <h3>Resources</h3>
             <ul>
@@ -149,6 +152,7 @@ const hasLinks = project.data.links && project.data.links.length > 0;
               ))}
             </ul>
           </div>
+          <!-- COLUMN: Support roles needed -->
           <div class="need-item">
             <h3>Support</h3>
             <ul>
@@ -160,14 +164,15 @@ const hasLinks = project.data.links && project.data.links.length > 0;
         </div>
       </section>
 
-      <!-- Project Timeline (CONDITIONAL) -->
+      <!-- SECTION (OPTIONAL): Project timeline milestones -->
       {hasTimeline && (
         <section class="content-section">
-          <SectionHeader 
+          <SectionHeader
             title="Project Timeline"
             align="left"
             headingLevel="h2"
           />
+          <!-- LIST: Chronological phases -->
           <div class="timeline">
             {project.data.timeline.map((phase) => (
               <div class="timeline-item">
@@ -184,15 +189,16 @@ const hasLinks = project.data.links && project.data.links.length > 0;
         </section>
       )}
 
-      <!-- How to Contribute (CONDITIONAL) -->
+      <!-- SECTION (OPTIONAL): Specific contribution paths -->
       {hasContributions && (
         <section class="content-section">
-          <SectionHeader 
+          <SectionHeader
             title="How to Contribute"
             subtitle="There are multiple ways to get involved, regardless of your background."
             align="left"
             headingLevel="h2"
           />
+          <!-- GRID: Contribution cards from content collection -->
           <div class="contribution-cards">
             {project.data.contributions.map((contrib) => (
               <div class="contrib-card">
@@ -206,21 +212,23 @@ const hasLinks = project.data.links && project.data.links.length > 0;
 
     </article>
 
-    <!-- LINKS & RESOURCES -->
+    <!-- SECTION: Links and resource downloads (with empty state) -->
     <Card as="section" class="resources-section">
-      <SectionHeader 
+      <SectionHeader
         title="Links & Resources"
         align="center"
         headingLevel="h2"
       />
-      
+
       {hasLinks ? (
         <>
+          <!-- INTRO TEXT: Context for resource list -->
           <p class="resources-intro">As this project develops, we'll share documentation, data, and code here. Everything stays open.</p>
+          <!-- GRID: External resources with status indicators -->
           <div class="links-grid">
             {project.data.links.map((link) => (
-              <a 
-                href={link.url || '#'} 
+              <a
+                href={link.url || '#'}
                 class={`resource-link ${link.status === 'coming-soon' ? 'disabled' : ''}`}
                 aria-disabled={link.status === 'coming-soon'}
               >
@@ -237,10 +245,11 @@ const hasLinks = project.data.links && project.data.links.length > 0;
           </div>
         </>
       ) : (
+        <!-- EMPTY STATE: Encourages contributors to supply resources -->
         <CalloutPanel variant="info">
           <p>
-            <strong>Documentation in progress.</strong> This project is in early stages. 
-            As we develop hypotheses, run experiments, and document findings, we'll share 
+            <strong>Documentation in progress.</strong> This project is in early stages.
+            As we develop hypotheses, run experiments, and document findings, we'll share
             everything here — data, code, CAD files, and learnings.
           </p>
           <p style="margin-bottom: 0;">
@@ -250,18 +259,20 @@ const hasLinks = project.data.links && project.data.links.length > 0;
       )}
     </Card>
 
-    <!-- JOIN CTA -->
+    <!-- CTA SECTION: Invitation to join or return to listing -->
     <Card as="section" class="join-cta-section">
-      <SectionHeader 
+      <SectionHeader
         title="Join This Project"
         subtitle="The project is in early stages, which means you can help shape the direction."
         align="center"
         headingLevel="h2"
       />
       <div class="cta-buttons">
+        <!-- CTA: External form for participation -->
         <LinkButton href={EXTERNAL_LINKS.formURL} variant="primary" icon="external">
           Get Involved
         </LinkButton>
+        <!-- CTA: Back navigation to project index -->
         <LinkButton href={withBase("/projects")} variant="outline" icon="arrow-right">
           ← Back to All Projects
         </LinkButton>

--- a/src/pages/test.astro
+++ b/src/pages/test.astro
@@ -47,7 +47,7 @@ const seo = buildSEO({
   <main id="main-content" class="page-shell" aria-labelledby="page-title">
 
     <!-- ================================================================ -->
-    <!-- HERO -->
+    <!-- HERO SECTION: Demonstrates scaffold hero pattern -->
     <!-- ================================================================ -->
     <header class="page-hero" aria-labelledby="page-title">
       <p class="eyebrow">Prototype Page</p>
@@ -61,7 +61,7 @@ const seo = buildSEO({
     <SectionDivider variant="subtle" spacing="compact" />
 
     <!-- ================================================================ -->
-    <!-- SECTION 1 — Overview / Context -->
+    <!-- SECTION: Overview/context template block -->
     <!-- ================================================================ -->
     <section class="page-section" aria-labelledby="section-1-title">
       <SectionHeader
@@ -87,7 +87,7 @@ const seo = buildSEO({
     <SectionDivider variant="default" spacing="normal" />
 
     <!-- ================================================================ -->
-    <!-- SECTION 2 — Grid / Feature Cards -->
+    <!-- SECTION: Example grid/feature card layout -->
     <!-- ================================================================ -->
     <section class="page-section" aria-labelledby="section-2-title">
       <SectionHeader
@@ -95,6 +95,7 @@ const seo = buildSEO({
         subtitle="Demonstrate a grid of features, categories, or key ideas."
         align="center"
       />
+      <!-- GRID: Mixed card variants for reference -->
       <div class="card-grid">
         <Card as="article" variant="surface">
           <h3>Card One card-grid</h3>
@@ -110,11 +111,12 @@ const seo = buildSEO({
     <SectionDivider variant="strong" spacing="spacious" />
 
     <!-- ================================================================ -->
-    <!-- SECTION 3 — VARIANTS (Choose One) -->
+    <!-- SECTION: Variant examples for downstream reuse -->
     <!-- ================================================================ -->
     <!--
       ── VARIANT A: Standard CTA
     -->
+    <!-- CTA SECTION: Standard gradient-style join prompt -->
     <section class="cta-section" aria-labelledby="cta-title">
       <SectionHeader
         title="Join the Work"
@@ -134,6 +136,7 @@ const seo = buildSEO({
     <!--
       ── VARIANT B: Outline Callout (How Page Style)
     -->
+    <!-- CALLOUT SECTION: Outline card grouping CTAs -->
     <section class="how-callout">
       <Card variant="outline">
         <div class="method-content">
@@ -158,6 +161,7 @@ const seo = buildSEO({
       ── VARIANT C: Reflection / Closing
     -->
 
+    <!-- REFLECTION SECTION: Closing sentiment pattern -->
     <section class="reflection-section" aria-labelledby="reflection-title">
       <SectionHeader
         title=class="reflection-section
@@ -174,6 +178,7 @@ const seo = buildSEO({
       ── VARIANT D: Final Join CTA (Encapsulated in Card)
     -->
 
+    <!-- CTA CARD SECTION: Final interest form prompt -->
     <Card as="section" class="final-cta" variant="surface" padding="spacious">
       <SectionHeader title="Ready to Join?" align="center" headingLevel="h2" />
       <p>


### PR DESCRIPTION
## Summary
- add descriptive HTML comments to every page under `src/pages` to document hero, section, grid, and card roles
- call out optional blocks, empty states, and CTA groupings so future scaffolding work can map components precisely
- include navigation context notes for breadcrumbs and links to support template assembly

## Testing
- not run (comments only)


------
https://chatgpt.com/codex/tasks/task_e_68e7a6de76e883309a58d18235c7d8a7